### PR TITLE
Comprehensive analysis of Aurelium Skills for null pointer exceptions and prep for null analysis annotations

### DIFF
--- a/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
+++ b/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
@@ -166,7 +166,13 @@ public class AureliumSkills extends JavaPlugin {
 	private Slate slate;
 	private MenuFileManager menuFileManager;
 	private ForgingLeveler forgingLeveler;
-
+	
+	public AureliumSkills() {
+		lang = new Lang(this);
+		manaAbilityManager = new ManaAbilityManager(this);
+		manaManager = new ManaManager(this);
+	}
+	
 	@Override
 	public void onEnable() {
 		// Registries
@@ -253,7 +259,6 @@ public class AureliumSkills extends JavaPlugin {
 		// Load	items
 		itemRegistry.loadFromFile();
 		// Load languages
-		lang = new Lang(this);
 		getServer().getPluginManager().registerEvents(lang, this);
 		lang.init();
 		lang.loadEmbeddedMessages(commandManager);
@@ -268,7 +273,6 @@ public class AureliumSkills extends JavaPlugin {
 		// Registers events
 		registerEvents();
 		// Load ability manager
-		manaAbilityManager = new ManaAbilityManager(this);
 		getServer().getPluginManager().registerEvents(manaAbilityManager, this);
 		manaAbilityManager.init();
 		// Load ability options
@@ -457,7 +461,11 @@ public class AureliumSkills extends JavaPlugin {
 		});
 		commandManager.getCommandContexts().registerContext(Skill.class, c -> {
 			String input = c.popFirstArg();
-			Skill skill = skillRegistry.getSkill(input);
+			Skill skill = null;
+			
+			if (input != null)
+				skill = skillRegistry.getSkill(input);
+			
 			if (skill != null) {
 				return skill;
 			} else {
@@ -590,7 +598,6 @@ public class AureliumSkills extends JavaPlugin {
 		pm.registerEvents(new ForgingAbilities(this), this);
 		pm.registerEvents(new DamageListener(this, defenseAbilities, fightingAbilities), this);
 		// Load mana manager
-		manaManager = new ManaManager(this);
 		getServer().getPluginManager().registerEvents(manaManager, this);
 		manaManager.startRegen();
 		ItemListener itemListener = new ItemListener(this);

--- a/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
+++ b/src/main/java/com/archyx/aureliumskills/AureliumSkills.java
@@ -116,6 +116,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class AureliumSkills extends JavaPlugin {
 
@@ -249,7 +250,7 @@ public class AureliumSkills extends JavaPlugin {
 			holographicDisplaysEnabled = false;
 		}
 		commandManager = new PaperCommandManager(this);
-		// Load	items
+		// Load items
 		itemRegistry.loadFromFile();
 		// Load languages
 		lang = new Lang(this);
@@ -438,8 +439,8 @@ public class AureliumSkills extends JavaPlugin {
 				saveConfig();
 			}
 		} catch (Exception e) {
-            e.printStackTrace();
-        }
+			e.printStackTrace();
+		}
 	}
 
 	private void registerCommands() {
@@ -448,7 +449,7 @@ public class AureliumSkills extends JavaPlugin {
 		getCommandManager().getCommandContexts().registerContext(Stat.class, c -> {
 			String input = c.popFirstArg();
 			if (input == null)
-			    throw new IndexOutOfBoundsException();
+				throw new IndexOutOfBoundsException();
 			Stat stat = statRegistry.getStat(input);
 			if (stat != null) {
 				return stat;
@@ -662,79 +663,56 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public RewardManager getRewardManager() {
-        RewardManager rewardManager = this.rewardManager;
-        if (rewardManager == null)
-            throw new IllegalStateException("RewardManager has not been initialized");
+		Objects.requireNonNull(rewardManager);
 		return rewardManager;
 	}
 
 	public PlayerManager getPlayerManager() {
-        PlayerManager playerManager = this.playerManager;
-        if (playerManager == null)
-            throw new IllegalStateException("PlayerManager has not been initialized!");
+		Objects.requireNonNull(playerManager);
 		return playerManager;
 	}
 
 	public Economy getEconomy() {
-        Economy economy = this.economy;
-        if (economy == null)
-            throw new IllegalStateException("Economy has not been initialized");
+		Objects.requireNonNull(economy);
 		return economy;
 	}
 
 	public LootTableManager getLootTableManager() {
-        LootTableManager lootTableManager = this.lootTableManager;
-        if (lootTableManager == null)
-            throw new IllegalStateException("LootTableManager has not been initialized");
+		Objects.requireNonNull(lootTableManager);
 		return lootTableManager;
 	}
 
 	public InventoryManager getInventoryManager() {
-        InventoryManager inventoryManager = this.inventoryManager;
-        if (inventoryManager == null)
-            throw new IllegalStateException("InventoryManager has not been initialized");
+		Objects.requireNonNull(inventoryManager);
 		return inventoryManager;
 	}
 
 	public AbilityManager getAbilityManager() {
-        AbilityManager abilityManager = this.abilityManager;
-        if (abilityManager == null)
-            throw new IllegalStateException("AbilityManager has not been initialized");
+		Objects.requireNonNull(abilityManager);
 		return abilityManager;
 	}
 
 	public WorldGuardSupport getWorldGuardSupport() {
-        WorldGuardSupport worldGuardSupport = this.worldGuardSupport;
-        if (worldGuardSupport == null)
-            throw new IllegalStateException("WorldGuardSupport has not been initialized");
 		return worldGuardSupport;
 	}
 
 	public WorldManager getWorldManager() {
-        WorldManager worldManager = this.worldManager;
-        if (worldManager == null)
-            throw new IllegalStateException("WorldManager has not been initialized");
+		Objects.requireNonNull(worldManager);
 		return worldManager;
 	}
 
 	public ManaManager getManaManager() {
-        ManaManager manaManager = this.manaManager;
-        if (manaManager == null)
-            throw new IllegalStateException("ManaManager has not been initialized");
+		Objects.requireNonNull(manaManager);
 		return manaManager;
 	}
 
 	public ManaAbilityManager getManaAbilityManager() {
-        ManaAbilityManager manaAbilityManager = this.manaAbilityManager;
-        if (manaAbilityManager == null)
-            throw new IllegalStateException("ManaAbilityManager has not been initialized");
+		Objects.requireNonNull(manaAbilityManager);
 		return manaAbilityManager;
 	}
 
 	public PaperCommandManager getCommandManager() {
-	    PaperCommandManager commandManager = this.commandManager;
-	    if (commandManager == null)
-	        throw new IllegalStateException("PaperCommandManager has not been initialized");
+		Objects.requireNonNull(commandManager);
 		return commandManager;
 	}
 
@@ -743,53 +721,62 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public ActionBar getActionBar() {
+		Objects.requireNonNull(actionBar);
 		return actionBar;
 	}
 
 	public SkillBossBar getBossBar() {
+		Objects.requireNonNull(bossBar);
 		return bossBar;
 	}
 
 	public SourceManager getSourceManager() {
+		Objects.requireNonNull(sourceManager);
 		return sourceManager;
 	}
 
 	public SorceryLeveler getSorceryLeveler() {
+		Objects.requireNonNull(sorceryLeveler);
 		return sorceryLeveler;
 	}
 
 	public RegionBlockListener getCheckBlockReplace() {
+		Objects.requireNonNull(regionBlockListener);
 		return regionBlockListener;
 	}
 
 	public RequirementManager getRequirementManager() {
+		Objects.requireNonNull(requirementManager);
 		return requirementManager;
 	}
 
 	public OptionL getOptionLoader() {
+		Objects.requireNonNull(optionLoader);
 		return optionLoader;
 	}
 
 	public ModifierManager getModifierManager() {
+		Objects.requireNonNull(modifierManager);
 		return modifierManager;
 	}
 
 	public Lang getLang() {
-        Lang lang = this.lang;
-        if (lang == null)
-            throw new IllegalStateException("Lang has not been initialized");
+		Objects.requireNonNull(lang);
 		return lang;
 	}
 
 	public Leveler getLeveler() {
+		Objects.requireNonNull(leveler);
 		return leveler;
 	}
 
 	public boolean isHolographicDisplaysEnabled() {
+		Objects.requireNonNull(holographicDisplaysEnabled);
 		return holographicDisplaysEnabled;
 	}
 
 	public boolean isWorldGuardEnabled() {
+		Objects.requireNonNull(worldGuardEnabled);
 		return worldGuardEnabled;
 	}
 
@@ -818,10 +805,12 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public Health getHealth() {
+		Objects.requireNonNull(health);
 		return health;
 	}
 
 	public StorageProvider getStorageProvider() {
+		Objects.requireNonNull(storageProvider);
 		return storageProvider;
 	}
 
@@ -830,10 +819,12 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public BackupProvider getBackupProvider() {
+		Objects.requireNonNull(backupProvider);
 		return backupProvider;
 	}
 
 	public LeaderboardManager getLeaderboardManager() {
+		Objects.requireNonNull(leaderboardManager);
 		return leaderboardManager;
 	}
 
@@ -846,14 +837,17 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public RegionManager getRegionManager() {
+		Objects.requireNonNull(regionManager);
 		return regionManager;
 	}
 
 	public StatRegistry getStatRegistry() {
+		Objects.requireNonNull(statRegistry);
 		return statRegistry;
 	}
 
 	public SkillRegistry getSkillRegistry() {
+		Objects.requireNonNull(skillRegistry);
 		return skillRegistry;
 	}
 
@@ -862,10 +856,12 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public SourceRegistry getSourceRegistry() {
+		Objects.requireNonNull(sourceRegistry);
 		return sourceRegistry;
 	}
 
 	public ItemRegistry getItemRegistry() {
+		Objects.requireNonNull(itemRegistry);
 		return itemRegistry;
 	}
 
@@ -882,6 +878,7 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public Slate getSlate() {
+		Objects.requireNonNull(slate);
 		return slate;
 	}
 
@@ -890,10 +887,12 @@ public class AureliumSkills extends JavaPlugin {
 	}
 
 	public MenuFileManager getMenuFileManager() {
+		Objects.requireNonNull(menuFileManager);
 		return menuFileManager;
 	}
 
 	public ForgingLeveler getForgingLeveler() {
+		Objects.requireNonNull(forgingLeveler);
 		return forgingLeveler;
 	}
 }

--- a/src/main/java/com/archyx/aureliumskills/ability/Ability.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/Ability.java
@@ -102,7 +102,7 @@ public enum Ability implements AbstractAbility {
 		this.options = new HashMap<>();
 	}
 
-	Ability(Supplier<Skill> skill, double baseValue, double valuePerLevel, String [] optionKeys, Object [] optionValues) {
+	Ability(Supplier<Skill> skill, double baseValue, double valuePerLevel, String[] optionKeys, Object[] optionValues) {
 		this(skill, baseValue, valuePerLevel);
 		this.options = new HashMap<>();
 		for (int i = 0; i < optionKeys.length; i++) {
@@ -119,7 +119,7 @@ public enum Ability implements AbstractAbility {
 		this.valuePerLevel2 = valuePerLevel2;
 	}
 
-	Ability(Supplier<Skill> skill, double baseValue1, double valuePerLevel1, double baseValue2, double valuePerLevel2, String [] optionKeys, Object [] optionValues) {
+	Ability(Supplier<Skill> skill, double baseValue1, double valuePerLevel1, double baseValue2, double valuePerLevel2, String[] optionKeys, Object[] optionValues) {
 		this(skill, baseValue1, valuePerLevel1, baseValue2, valuePerLevel2);
 		this.options = new HashMap<>();
 		for (int i = 0; i < optionKeys.length; i++) {

--- a/src/main/java/com/archyx/aureliumskills/ability/Ability.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/Ability.java
@@ -99,9 +99,10 @@ public enum Ability implements AbstractAbility {
 		this.baseValue = baseValue;
 		this.valuePerLevel = valuePerLevel;
 		this.skill = skill;
+		this.options = new HashMap<>();
 	}
 
-	Ability(Supplier<Skill> skill, double baseValue, double valuePerLevel, String[] optionKeys, Object[] optionValues) {
+	Ability(Supplier<Skill> skill, double baseValue, double valuePerLevel, String [] optionKeys, Object [] optionValues) {
 		this(skill, baseValue, valuePerLevel);
 		this.options = new HashMap<>();
 		for (int i = 0; i < optionKeys.length; i++) {
@@ -118,7 +119,7 @@ public enum Ability implements AbstractAbility {
 		this.valuePerLevel2 = valuePerLevel2;
 	}
 
-	Ability(Supplier<Skill> skill, double baseValue1, double valuePerLevel1, double baseValue2, double valuePerLevel2, String[] optionKeys, Object[] optionValues) {
+	Ability(Supplier<Skill> skill, double baseValue1, double valuePerLevel1, double baseValue2, double valuePerLevel2, String [] optionKeys, Object [] optionValues) {
 		this(skill, baseValue1, valuePerLevel1, baseValue2, valuePerLevel2);
 		this.options = new HashMap<>();
 		for (int i = 0; i < optionKeys.length; i++) {

--- a/src/main/java/com/archyx/aureliumskills/ability/AbilityManager.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/AbilityManager.java
@@ -15,7 +15,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.InputStream;
@@ -214,7 +213,6 @@ public class AbilityManager {
         try {
             for (String abilityName : abilities.getKeys(false)) {
                 String newKey = TextUtil.replace(abilityName, "-", "_");
-                assert (null != newKey);
                 newKey = newKey.toUpperCase();
                 if (isAbility(newKey)) {
                     Ability ability = Ability.valueOf(newKey);
@@ -238,7 +236,6 @@ public class AbilityManager {
             if (manaAbilities != null) {
                 for (String manaAbilityName : manaAbilities.getKeys(false)) {
                     String newKey = TextUtil.replace(manaAbilityName, "-", "_");
-                    assert (null != newKey);
                     newKey = newKey.toUpperCase();
                     if (isManaAbility(newKey)) {
                         MAbility mAbility = MAbility.valueOf(newKey);
@@ -279,8 +276,9 @@ public class AbilityManager {
     }
 
     public boolean isEnabled(Ability ability) {
-        if (abilityOptions.containsKey(ability)) {
-            return abilityOptions.get(ability).isEnabled();
+        AbilityOption option = abilityOptions.get(ability);
+        if (option != null) {
+            return option.isEnabled();
         }
         return true;
     }
@@ -290,8 +288,9 @@ public class AbilityManager {
     }
 
     public boolean isEnabled(MAbility mAbility) {
-        if (manaAbilityOptions.containsKey(mAbility)) {
-            return manaAbilityOptions.get(mAbility).isEnabled();
+        ManaAbilityOption option = manaAbilityOptions.get(mAbility);
+        if (option != null) {
+            return option.isEnabled();
         }
         return true;
     }
@@ -405,16 +404,13 @@ public class AbilityManager {
     public boolean getOptionAsBooleanElseTrue(Ability ability, String key) {
         OptionValue value = getOption(ability, key);
         if (value != null) {
-            if (value.getValue() != null) {
-                return value.asBoolean();
-            }
+            return value.asBoolean();
         }
         return true;
     }
 
-    @Nullable
     public Set<String> getOptionKeys(Ability ability) {
-        if (ability.getDefaultOptions() != null) {
+        if (!ability.getDefaultOptions().isEmpty()) {
             return ability.getDefaultOptions().keySet();
         }
         return null;

--- a/src/main/java/com/archyx/aureliumskills/ability/AbilityManager.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/AbilityManager.java
@@ -213,7 +213,9 @@ public class AbilityManager {
         if (abilities == null) return;
         try {
             for (String abilityName : abilities.getKeys(false)) {
-                String newKey = TextUtil.replace(abilityName, "-", "_").toUpperCase();
+                String newKey = TextUtil.replace(abilityName, "-", "_");
+                assert (null != newKey);
+                newKey = newKey.toUpperCase();
                 if (isAbility(newKey)) {
                     Ability ability = Ability.valueOf(newKey);
                     boolean enabled = abilities.getBoolean(abilityName + ".enabled", true);
@@ -235,7 +237,9 @@ public class AbilityManager {
             ConfigurationSection manaAbilities = config.getConfigurationSection("mana-abilities");
             if (manaAbilities != null) {
                 for (String manaAbilityName : manaAbilities.getKeys(false)) {
-                    String newKey = TextUtil.replace(manaAbilityName, "-", "_").toUpperCase();
+                    String newKey = TextUtil.replace(manaAbilityName, "-", "_");
+                    assert (null != newKey);
+                    newKey = newKey.toUpperCase();
                     if (isManaAbility(newKey)) {
                         MAbility mAbility = MAbility.valueOf(newKey);
                         boolean enabled = manaAbilities.getBoolean(manaAbilityName + ".enabled", true);

--- a/src/main/java/com/archyx/aureliumskills/ability/AbilityOption.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/AbilityOption.java
@@ -1,7 +1,6 @@
 package com.archyx.aureliumskills.ability;
 
 import com.archyx.aureliumskills.configuration.OptionValue;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -91,7 +90,6 @@ public class AbilityOption {
         return maxLevel;
     }
 
-    @Nullable
     public OptionValue getOption(String key) {
         return options.get(key);
     }

--- a/src/main/java/com/archyx/aureliumskills/ability/AbilityProvider.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/AbilityProvider.java
@@ -56,12 +56,10 @@ public abstract class AbilityProvider {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             double output = plugin.getSourceManager().getXp(source);
-            if (ability != null) {
-                if (plugin.getAbilityManager().isEnabled(ability)) {
-                    double modifier = 1;
-                    modifier += plugin.getAbilityManager().getValue(ability, playerData.getAbilityLevel(ability)) / 100;
-                    output *= modifier;
-                }
+            if (plugin.getAbilityManager().isEnabled(ability)) {
+                double modifier = 1;
+                modifier += plugin.getAbilityManager().getValue(ability, playerData.getAbilityLevel(ability)) / 100;
+                output *= modifier;
             }
             return output;
         }

--- a/src/main/java/com/archyx/aureliumskills/ability/AbstractAbility.java
+++ b/src/main/java/com/archyx/aureliumskills/ability/AbstractAbility.java
@@ -2,7 +2,6 @@ package com.archyx.aureliumskills.ability;
 
 import com.archyx.aureliumskills.mana.MAbility;
 import com.archyx.aureliumskills.skills.Skill;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -14,7 +13,6 @@ public interface AbstractAbility {
 
     double getDefaultValuePerLevel();
 
-    @Nullable
     static AbstractAbility valueOf(String abilityName) {
         try {
             return Ability.valueOf(abilityName.toUpperCase(Locale.ROOT));

--- a/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
+++ b/src/main/java/com/archyx/aureliumskills/api/AureliumAPI.java
@@ -15,6 +15,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public class AureliumAPI {
@@ -41,6 +42,7 @@ public class AureliumAPI {
      * @return AureliumSkills instance.
      */
     public static AureliumSkills getPlugin() {
+        AureliumSkills plugin = AureliumAPI.plugin;
         if (plugin == null) {
             throw new IllegalStateException("The AureliumSkills API is not loaded yet");
         }
@@ -52,6 +54,7 @@ public class AureliumAPI {
      * @return the current mana of a player
      */
     public static double getMana(Player player) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getMana();
@@ -61,6 +64,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static double getMana(UUID playerId) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             return playerData.getMana();
@@ -73,6 +77,7 @@ public class AureliumAPI {
      * @return the max mana of a player
      */
     public static double getMaxMana(Player player) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getMaxMana();
@@ -86,6 +91,7 @@ public class AureliumAPI {
      * @return the mana regeneration per second of a player
      */
     public static double getManaRegen(Player player) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getManaRegen();
@@ -96,6 +102,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static double getMaxMana(UUID playerId) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             return playerData.getMaxMana();
@@ -108,6 +115,7 @@ public class AureliumAPI {
      * Sets a player's mana to an amount
      */
     public static void setMana(Player player, double amount) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             playerData.setMana(amount);
@@ -116,6 +124,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static void setMana(UUID playerId, double amount) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             playerData.setMana(amount);
@@ -126,6 +135,7 @@ public class AureliumAPI {
      * Adds Skill XP to a player for a certain skill, and includes multiplier permissions
      */
     public static void addXp(Player player, Skill skill, double amount) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         plugin.getLeveler().addXp(player, skill, amount);
     }
 
@@ -133,6 +143,8 @@ public class AureliumAPI {
      * Adds Skill XP to a player for a certain skill, without multipliers
      */
     public static void addXpRaw(Player player, Skill skill, double amount) {
+        AureliumSkills plugin = AureliumAPI.plugin;
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             playerData.addSkillXp(skill, amount);
@@ -146,6 +158,7 @@ public class AureliumAPI {
      */
     @Deprecated
     public static boolean addXpOffline(OfflinePlayer player, Skill skill, double amount) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player.getUniqueId());
         if (playerData != null) {
             playerData.addSkillXp(skill, amount);
@@ -158,6 +171,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static boolean addXpOffline(UUID playerId, Skill skill, double amount) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             playerData.addSkillXp(skill, amount);
@@ -173,6 +187,7 @@ public class AureliumAPI {
      * @return the skill level of a player, or 1 if player does not have a skills profile
      */
     public static int getSkillLevel(Player player, Skill skill) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getSkillLevel(skill);
@@ -184,6 +199,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static int getSkillLevel(UUID playerId, Skill skill) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             return playerData.getSkillLevel(skill);
@@ -200,6 +216,7 @@ public class AureliumAPI {
      * @return The current skill xp
      */
     public static double getXp(Player player, Skill skill) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getSkillXp(skill);
@@ -211,9 +228,10 @@ public class AureliumAPI {
 
     @Deprecated
     public static double getXp(UUID playerId, Skill skill) {
-        PlayerData playerSkill = plugin.getPlayerManager().getPlayerData(playerId);
-        if (playerSkill != null) {
-            return playerSkill.getSkillXp(skill);
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
+        PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
+        if (playerData != null) {
+            return playerData.getSkillXp(skill);
         }
         else {
             return 1;
@@ -227,6 +245,7 @@ public class AureliumAPI {
      * @return The stat level
      */
     public static double getStatLevel(Player player, Stat stat) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getStatLevel(stat);
@@ -238,6 +257,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static double getStatLevel(UUID playerId, Stat stat) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             return playerData.getStatLevel(stat);
@@ -255,6 +275,7 @@ public class AureliumAPI {
      */
     @Deprecated
     public static double getBaseStatLevel(Player player, Stat stat) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             return playerData.getStatLevel(stat);
@@ -266,6 +287,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static double getBaseStatLevel(UUID playerId, Stat stat) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             return playerData.getStatLevel(stat);
@@ -284,6 +306,7 @@ public class AureliumAPI {
      * @return true if a modifier was added, false if the player does not have a skills profile
      */
     public static boolean addStatModifier(Player player, String name, Stat stat, double value) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             playerData.addStatModifier(new StatModifier(name, stat, value));
@@ -294,6 +317,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static boolean addStatModifier(UUID playerId, String name, Stat stat, double value) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             playerData.addStatModifier(new StatModifier(name, stat, value));
@@ -309,6 +333,7 @@ public class AureliumAPI {
      * @return true if the operation was successful, false if the stat modifier was not found or the player does not have a skills profile
      */
     public static boolean removeStatModifier(Player player, String name) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             playerData.removeStatModifier(name);
@@ -319,6 +344,7 @@ public class AureliumAPI {
 
     @Deprecated
     public static boolean removeStatModifier(UUID playerId, String name) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(playerId);
         if (playerData != null) {
             playerData.removeStatModifier(name);
@@ -338,6 +364,7 @@ public class AureliumAPI {
      * @return A new ItemStack with the item modifier
      */
     public static ItemStack addItemModifier(ItemStack item, Stat stat, double value, boolean lore) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         Modifiers modifiers = new Modifiers(plugin);
         ItemStack modifiedItem = modifiers.addModifier(ModifierType.ITEM, item, stat, value);
         if (lore) {
@@ -357,6 +384,7 @@ public class AureliumAPI {
      * @return A new ItemStack with the armor modifier
      */
     public static ItemStack addArmorModifier(ItemStack item, Stat stat, double value, boolean lore) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         Modifiers modifiers = new Modifiers(plugin);
         ItemStack modifiedItem = modifiers.addModifier(ModifierType.ARMOR, item, stat, value);
         if (lore) {
@@ -376,6 +404,7 @@ public class AureliumAPI {
      * @return A new ItemStack with the item modifier
      */
     public static ItemStack addItemMultiplier(ItemStack item, Skill skill, double value, boolean lore) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         Multipliers multipliers = new Multipliers(plugin);
         ItemStack modifiedItem = multipliers.addMultiplier(ModifierType.ITEM, item, skill, value);
         if (lore) {
@@ -395,6 +424,7 @@ public class AureliumAPI {
      * @return A new ItemStack with the armor modifier
      */
     public static ItemStack addArmorMultiplier(ItemStack item, Skill skill, double value, boolean lore) {
+        Objects.requireNonNull(plugin, "The AureliumSkills API is not loaded yet");
         Multipliers multipliers = new Multipliers(plugin);
         ItemStack modifiedItem = multipliers.addMultiplier(ModifierType.ITEM, item, skill, value);
         if (lore) {

--- a/src/main/java/com/archyx/aureliumskills/api/event/CustomRegenEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/CustomRegenEvent.java
@@ -3,7 +3,6 @@ package com.archyx.aureliumskills.api.event;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class CustomRegenEvent extends Event {
 
@@ -45,7 +44,6 @@ public class CustomRegenEvent extends Event {
         this.isCancelled = cancelled;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityActivateEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityActivateEvent.java
@@ -4,7 +4,6 @@ import com.archyx.aureliumskills.mana.MAbility;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class ManaAbilityActivateEvent extends Event {
 
@@ -46,7 +45,6 @@ public class ManaAbilityActivateEvent extends Event {
         this.duration = duration;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityRefreshEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/ManaAbilityRefreshEvent.java
@@ -4,7 +4,6 @@ import com.archyx.aureliumskills.mana.MAbility;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class ManaAbilityRefreshEvent extends Event {
 
@@ -27,7 +26,6 @@ public class ManaAbilityRefreshEvent extends Event {
         return manaAbility;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/archyx/aureliumskills/api/event/ManaRegenerateEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/ManaRegenerateEvent.java
@@ -3,7 +3,6 @@ package com.archyx.aureliumskills.api.event;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class ManaRegenerateEvent extends Event {
 
@@ -39,7 +38,6 @@ public class ManaRegenerateEvent extends Event {
         this.isCancelled = cancelled;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/archyx/aureliumskills/api/event/PlayerLootDropEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/PlayerLootDropEvent.java
@@ -5,7 +5,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when an ability or luck causes extra items to drop from an action. Does not include the original or normal items dropped except for Fishing Lucky Catch.
@@ -60,7 +59,6 @@ public class PlayerLootDropEvent extends Event {
         this.isCancelled = cancelled;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/archyx/aureliumskills/api/event/TerraformBlockBreakEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/api/event/TerraformBlockBreakEvent.java
@@ -3,11 +3,10 @@ package com.archyx.aureliumskills.api.event;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
-import org.jetbrains.annotations.NotNull;
 
 public class TerraformBlockBreakEvent extends BlockBreakEvent {
 
-    public TerraformBlockBreakEvent(@NotNull Block theBlock, @NotNull Player player) {
+    public TerraformBlockBreakEvent(Block theBlock, Player player) {
         super(theBlock, player);
     }
 

--- a/src/main/java/com/archyx/aureliumskills/commands/ManaCommand.java
+++ b/src/main/java/com/archyx/aureliumskills/commands/ManaCommand.java
@@ -31,7 +31,8 @@ public class ManaCommand extends BaseCommand {
         if (sender instanceof Player && player == null) {
             Player target = (Player) sender;
             PlayerData playerData = plugin.getPlayerManager().getPlayerData(target);
-            if (playerData == null) return;
+            if (playerData == null)
+                return;
             Locale locale = playerData.getLocale();
             sender.sendMessage(AureliumSkills.getPrefix(locale) + TextUtil.replace(Lang.getMessage(CommandMessage.MANA_DISPLAY, locale)
                     , "{current}", NumberUtil.format1(playerData.getMana())

--- a/src/main/java/com/archyx/aureliumskills/commands/ReloadManager.java
+++ b/src/main/java/com/archyx/aureliumskills/commands/ReloadManager.java
@@ -4,6 +4,8 @@ import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.lang.CommandMessage;
 import com.archyx.aureliumskills.lang.Lang;
 import com.archyx.aureliumskills.stats.Luck;
+import com.archyx.aureliumskills.support.WorldGuardSupport;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -48,8 +50,9 @@ public class ReloadManager {
         plugin.getLootTableManager().loadLootTables();
         // Load worlds and regions
         plugin.getWorldManager().loadWorlds();
-        if (plugin.isWorldGuardEnabled()) {
-            plugin.getWorldGuardSupport().loadRegions();
+        WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+        if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+            worldGuardSupport.loadRegions();
         }
         // Recalculate health and luck stats
         Luck luck = new Luck(plugin);

--- a/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
+++ b/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
@@ -61,7 +61,9 @@ public class SkillsCommand extends BaseCommand {
 		if (plugin.getPlayerManager().hasPlayerData(player)) {
 			plugin.getMenuManager().openMenu(player, "skills");
 		} else {
-			player.sendMessage(Lang.getMessage(CommandMessage.NO_PROFILE, Lang.getDefaultLanguage()));
+			String m = Lang.getMessage(CommandMessage.NO_PROFILE, Lang.getDefaultLanguage());
+			assert (m != null);
+			player.sendMessage(m);
 		}
 	}
 	
@@ -74,7 +76,9 @@ public class SkillsCommand extends BaseCommand {
 		if (OptionL.isEnabled(skill)) {
 			plugin.getLeveler().addXp(player, skill, amount);
 			if (!silent) {
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_ADD, locale).replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+				String m = Lang.getMessage(CommandMessage.XP_ADD, locale);
+				assert (m != null);
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 			}
 		} else {
 			sender.sendMessage(AureliumSkills.getPrefix(locale) + ChatColor.YELLOW + Lang.getMessage(CommandMessage.UNKNOWN_SKILL, locale));
@@ -90,7 +94,9 @@ public class SkillsCommand extends BaseCommand {
 		if (OptionL.isEnabled(skill)) {
 			plugin.getLeveler().setXp(player, skill, amount);
 			if (!silent) {
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_SET, locale).replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+				String m = Lang.getMessage(CommandMessage.XP_SET, locale);
+				assert (m != null);
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 			}
 		} else {
 			sender.sendMessage(AureliumSkills.getPrefix(locale) + ChatColor.YELLOW + Lang.getMessage(CommandMessage.UNKNOWN_SKILL, locale));
@@ -109,11 +115,15 @@ public class SkillsCommand extends BaseCommand {
 			if (playerData.getSkillXp(skill) - amount >= 0) {
 				plugin.getLeveler().setXp(player, skill, playerData.getSkillXp(skill) - amount);
 				if (!silent) {
-					sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_REMOVE, locale).replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+					String m = Lang.getMessage(CommandMessage.XP_REMOVE, locale);
+					assert (m != null);
+					sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 				}
 			} else {
 				if (!silent) {
-					sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_REMOVE, locale).replace("{amount}", String.valueOf(playerData.getSkillXp(skill))).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+					String m = Lang.getMessage(CommandMessage.XP_REMOVE, locale);
+					assert (m != null);
+					sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(playerData.getSkillXp(skill))).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 				}
 				plugin.getLeveler().setXp(player, skill, 0);
 			}
@@ -128,14 +138,18 @@ public class SkillsCommand extends BaseCommand {
 	@CommandPermission("aureliumskills.top")
 	@Description("Shows the top players in a skill")
 	@Syntax("Usage: /sk top <page> or /sk top [skill] <page>")
-	public void onTop(CommandSender sender, String[] args) {
+	public void onTop(CommandSender sender, String [] args) {
 		Locale locale = plugin.getLang().getLocale(sender);
 		if (args.length == 0) {
 			List<SkillValue> lb = plugin.getLeaderboardManager().getPowerLeaderboard(1, 10);
-			sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_HEADER, locale));
+			String m = Lang.getMessage(CommandMessage.TOP_POWER_HEADER, locale);
+			assert (m != null);
+			sender.sendMessage(m);
 			for (SkillValue skillValue : lb) {
 				String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-				sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale)
+				m = Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale);
+				assert (null != m);
+				sender.sendMessage(m
 						.replace("{rank}", String.valueOf(lb.indexOf(skillValue) + 1))
 						.replace("{player}", name != null ? name : "?")
 						.replace("{level}", String.valueOf(skillValue.getLevel())));
@@ -144,16 +158,22 @@ public class SkillsCommand extends BaseCommand {
 		else if (args.length == 1) {
 			if (args[0].equalsIgnoreCase("average")) {
 				List<SkillValue> lb = plugin.getLeaderboardManager().getAverageLeaderboard(1, 10);
-				sender.sendMessage(Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER, locale));
+				String m = Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER, locale);
+				assert (m != null);
+				sender.sendMessage(m);
 				sendLeaderboardEntries(sender, locale, lb);
 			} else {
 				try {
 					int page = Integer.parseInt(args[0]);
 					List<SkillValue> lb = plugin.getLeaderboardManager().getPowerLeaderboard(page, 10);
-					sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_HEADER_PAGE, locale).replace("{page}", String.valueOf(page)));
+					String m = Lang.getMessage(CommandMessage.TOP_POWER_HEADER_PAGE, locale);
+					assert (null != m);
+					sender.sendMessage(m.replace("{page}", String.valueOf(page)));
 					for (SkillValue skillValue : lb) {
 						String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale)
+						m = Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale);
+						assert (null != m);
+						sender.sendMessage(m
 								.replace("{rank}", String.valueOf((page - 1) * 10 + lb.indexOf(skillValue) + 1))
 								.replace("{player}", name != null ? name : "?")
 								.replace("{level}", String.valueOf(skillValue.getLevel())));
@@ -162,16 +182,22 @@ public class SkillsCommand extends BaseCommand {
 					Skill skill = plugin.getSkillRegistry().getSkill(args[0]);
 					if (skill != null) {
 						List<SkillValue> lb = plugin.getLeaderboardManager().getLeaderboard(skill, 1, 10);
-						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_HEADER, locale).replace("{skill}", skill.getDisplayName(locale)));
+						String m = Lang.getMessage(CommandMessage.TOP_SKILL_HEADER, locale);
+						assert (null != m);
+						sender.sendMessage(m.replace("{skill}", skill.getDisplayName(locale)));
 						for (SkillValue skillValue : lb) {
 							String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-							sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale)
+							m = Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale);
+							assert (null != m);
+							sender.sendMessage(m
 									.replace("{rank}", String.valueOf(lb.indexOf(skillValue) + 1))
 									.replace("{player}", name != null ? name : "?")
 									.replace("{level}", String.valueOf(skillValue.getLevel())));
 						}
 					} else {
-						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
+						String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
+						assert (m != null);
+						sender.sendMessage(m);
 					}
 				}
 			}
@@ -181,11 +207,14 @@ public class SkillsCommand extends BaseCommand {
 				try {
 					int page = Integer.parseInt(args[1]);
 					List<SkillValue> lb = plugin.getLeaderboardManager().getAverageLeaderboard(page, 10);
-					sender.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER_PAGE, locale),
-							"{page}", String.valueOf(page)));
+					String m = TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER_PAGE, locale), "{page}", String.valueOf(page));
+					assert (m != null);
+					sender.sendMessage(m);
 					sendLeaderboardEntries(sender, locale, lb);
 				} catch (Exception e) {
-					sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
+					String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
+					assert (m != null);
+					sender.sendMessage(m);
 				}
 			} else {
 				Skill skill = plugin.getSkillRegistry().getSkill(args[0]);
@@ -193,19 +222,27 @@ public class SkillsCommand extends BaseCommand {
 					try {
 						int page = Integer.parseInt(args[1]);
 						List<SkillValue> lb = plugin.getLeaderboardManager().getLeaderboard(skill, page, 10);
-						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_HEADER_PAGE, locale).replace("{page}", String.valueOf(page)).replace("{skill}", skill.getDisplayName(locale)));
+						String m = Lang.getMessage(CommandMessage.TOP_SKILL_HEADER_PAGE, locale);
+						assert (null != m);
+						sender.sendMessage(m.replace("{page}", String.valueOf(page)).replace("{skill}", skill.getDisplayName(locale)));
 						for (SkillValue skillValue : lb) {
 							String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-							sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale)
+							m = Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale);
+							assert (null != m);
+							sender.sendMessage(m
 									.replace("{rank}", String.valueOf((page - 1) * 10 + lb.indexOf(skillValue) + 1))
 									.replace("{player}", name != null ? name : "?")
 									.replace("{level}", String.valueOf(skillValue.getLevel())));
 						}
 					} catch (Exception e) {
-						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
+						String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
+						assert (m != null);
+						sender.sendMessage(m);
 					}
 				} else {
-					sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
+					String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
+					assert (m != null);
+					sender.sendMessage(m);
 				}
 			}
 		}
@@ -214,10 +251,14 @@ public class SkillsCommand extends BaseCommand {
 	private void sendLeaderboardEntries(CommandSender sender, Locale locale, List<SkillValue> lb) {
 		for (SkillValue skillValue : lb) {
 			String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-			sender.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_ENTRY, locale),
+			String m = TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_ENTRY, locale),
 					"{rank}", String.valueOf(lb.indexOf(skillValue) + 1),
 					"{player}", name != null ? name : "?",
-					"{level}", NumberUtil.format2(skillValue.getXp())));
+					"{level}", NumberUtil.format2(skillValue.getXp()));
+			
+			assert (null != m);
+			
+			sender.sendMessage(m);
 		}
 	}
 
@@ -294,13 +335,20 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Shows your skill rankings")
 	public void onRank(Player player) {
 		Locale locale = plugin.getLang().getLocale(player);
-		player.sendMessage(Lang.getMessage(CommandMessage.RANK_HEADER, locale));
-		player.sendMessage(Lang.getMessage(CommandMessage.RANK_POWER, locale)
+		String m;
+		m = Lang.getMessage(CommandMessage.RANK_HEADER, locale);
+		assert (m != null);
+		player.sendMessage(m);
+		m = Lang.getMessage(CommandMessage.RANK_POWER, locale);
+		assert (m != null);
+		player.sendMessage(m
 				.replace("{rank}", String.valueOf(plugin.getLeaderboardManager().getPowerRank(player.getUniqueId())))
 				.replace("{total}", String.valueOf(plugin.getLeaderboardManager().getPowerLeaderboard().size())));
 		for (Skill skill : plugin.getSkillRegistry().getSkills()) {
 			if (OptionL.isEnabled(skill)) {
-				player.sendMessage(Lang.getMessage(CommandMessage.RANK_ENTRY, locale)
+				m = Lang.getMessage(CommandMessage.RANK_ENTRY, locale);
+				assert (null != m);
+				player.sendMessage(m
 						.replace("{skill}", String.valueOf(skill.getDisplayName(locale)))
 						.replace("{rank}", String.valueOf(plugin.getLeaderboardManager().getSkillRank(skill, player.getUniqueId())))
 						.replace("{total}", String.valueOf(plugin.getLeaderboardManager().getLeaderboard(skill).size())));
@@ -319,10 +367,14 @@ public class SkillsCommand extends BaseCommand {
 			if (playerData == null) return;
 			playerData.setLocale(locale);
 			plugin.getCommandManager().setPlayerLocale(player, locale);
-			player.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.LANG_SET, locale).replace("{lang}", Lang.getDefinedLanguages().get(locale)));
+			String m = Lang.getMessage(CommandMessage.LANG_SET, locale);
+			assert (null != m);
+			player.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{lang}", Lang.getDefinedLanguages().get(locale)));
 		}
 		else {
-			player.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.LANG_NOT_FOUND, plugin.getLang().getLocale(player)));
+			String m = Lang.getMessage(CommandMessage.LANG_NOT_FOUND, plugin.getLang().getLocale(player));
+			assert (null != m);
+			player.sendMessage(AureliumSkills.getPrefix(locale) + m);
 		}
 	}
 	
@@ -352,8 +404,9 @@ public class SkillsCommand extends BaseCommand {
 				plugin.getLeveler().applyLevelUpCommands(player, skill, oldLevel, level);
 				// Reload items and armor to check for newly met requirements
 				this.plugin.getModifierManager().reloadPlayer(player);
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_SETLEVEL_SET, locale)
-						.replace("{skill}", skill.getDisplayName(locale))
+				String m = Lang.getMessage(CommandMessage.SKILL_SETLEVEL_SET, locale);
+				assert (null != m);
+				sender.sendMessage((AureliumSkills.getPrefix(locale) + m.replace("{skill}", skill.getDisplayName(locale)))
 						.replace("{level}", String.valueOf(level))
 						.replace("{player}", player.getName()));
 			} else {
@@ -387,7 +440,9 @@ public class SkillsCommand extends BaseCommand {
 			}
 			plugin.getLeveler().updateStats(player);
 			plugin.getLeveler().updatePermissions(player);
-			sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_SETALL_SET, locale)
+			String m = Lang.getMessage(CommandMessage.SKILL_SETALL_SET, locale);
+			assert (null != m);
+			sender.sendMessage(AureliumSkills.getPrefix(locale) + m
 					.replace("{level}", String.valueOf(level))
 					.replace("{player}", player.getName()));
 		} else {
@@ -409,7 +464,9 @@ public class SkillsCommand extends BaseCommand {
 				resetPlayerSkills(player, playerData, skill);
 				// Reload items and armor to check for newly met requirements
 				this.plugin.getModifierManager().reloadPlayer(player);
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_RESET_RESET_SKILL, locale)
+				String m = Lang.getMessage(CommandMessage.SKILL_RESET_RESET_SKILL, locale);
+				assert (null != m);
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + m
 						.replace("{skill}", skill.getDisplayName(locale))
 						.replace("{player}", player.getName()));
 			} else {
@@ -422,7 +479,9 @@ public class SkillsCommand extends BaseCommand {
 			for (Skill s : plugin.getSkillRegistry().getSkills()) {
 				resetPlayerSkills(player, playerData, s);
 			}
-			sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_RESET_RESET_ALL, locale)
+			String m = Lang.getMessage(CommandMessage.SKILL_RESET_RESET_ALL, locale);
+			assert (m != null);
+			sender.sendMessage(AureliumSkills.getPrefix(locale) + m
 					.replace("{player}", player.getName()));
 		}
 	}
@@ -814,12 +873,16 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Lists the item requirements on the item held.")
 	public void onItemRequirementList(@Flags("itemheld") Player player) {
 		Locale locale = plugin.getLang().getLocale(player);
-		player.sendMessage(Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_HEADER, locale));
+		String m = Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_HEADER, locale);
+		assert (m != null);
+		player.sendMessage(m);
 		Requirements requirements = new Requirements(plugin);
 		for (Map.Entry<Skill, Integer> entry : requirements.getRequirements(ModifierType.ITEM, player.getInventory().getItemInMainHand()).entrySet()) {
-			player.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_ENTRY, locale),
+			m = TextUtil.replace(Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_ENTRY, locale),
 					"{skill}", entry.getKey().getDisplayName(locale),
-					"{level}", String.valueOf(entry.getValue())));
+					"{level}", String.valueOf(entry.getValue()));
+			assert (m != null);
+			player.sendMessage(m);
 		}
 	}
 
@@ -885,12 +948,16 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Lists the armor requirements on the item held.")
 	public void onArmorRequirementList(@Flags("itemheld") Player player) {
 		Locale locale = plugin.getLang().getLocale(player);
-		player.sendMessage(Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_HEADER, locale));
+		String m = Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_HEADER, locale);
+		assert (m != null);
+		player.sendMessage(m);
 		Requirements requirements = new Requirements(plugin);
 		for (Map.Entry<Skill, Integer> entry : requirements.getRequirements(ModifierType.ARMOR, player.getInventory().getItemInMainHand()).entrySet()) {
-			player.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_ENTRY, locale),
+			m = TextUtil.replace(Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_ENTRY, locale),
 					"{skill}", entry.getKey().getDisplayName(locale),
-					"{level}", String.valueOf(entry.getValue())));
+					"{level}", String.valueOf(entry.getValue()));
+			assert (m != null);
+			player.sendMessage(m);
 		}
 	}
 
@@ -1261,8 +1328,9 @@ public class SkillsCommand extends BaseCommand {
 		Multipliers multipliers = new Multipliers(plugin);
 		for (Multiplier multiplier : multipliers.getMultipliers(ModifierType.ITEM, item)) {
 			String targetName;
-			if (multiplier.getSkill() != null) {
-				targetName = multiplier.getSkill().getDisplayName(locale);
+			Skill skill = multiplier.getSkill();
+			if (skill != null) {
+				targetName = skill.getDisplayName(locale);
 			} else {
 				targetName = Lang.getMessage(CommandMessage.MULTIPLIER_GLOBAL, locale);
 			}
@@ -1376,8 +1444,9 @@ public class SkillsCommand extends BaseCommand {
 		Multipliers multipliers = new Multipliers(plugin);
 		for (Multiplier multiplier : multipliers.getMultipliers(ModifierType.ARMOR, item)) {
 			String targetName;
-			if (multiplier.getSkill() != null) {
-				targetName = multiplier.getSkill().getDisplayName(locale);
+			Skill skill = multiplier.getSkill();
+			if (skill != null) {
+				targetName = skill.getDisplayName(locale);
 			} else {
 				targetName = Lang.getMessage(CommandMessage.MULTIPLIER_GLOBAL, locale);
 			}

--- a/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
+++ b/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
@@ -1037,11 +1037,9 @@ public class SkillsCommand extends BaseCommand {
 	@CommandPermission("aureliumskills.backup.save")
 	public void onBackupSave(CommandSender sender) {
 		BackupProvider backupProvider = plugin.getBackupProvider();
-		if (backupProvider != null) {
-			Locale locale = plugin.getLang().getLocale(sender);
-			sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_SAVE_SAVING, locale));
-			backupProvider.saveBackup(sender, true);
-		}
+		Locale locale = plugin.getLang().getLocale(sender);
+		sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_SAVE_SAVING, locale));
+		backupProvider.saveBackup(sender, true);
 	}
 
 	@Subcommand("backup load")
@@ -1049,36 +1047,32 @@ public class SkillsCommand extends BaseCommand {
 	public void onBackupLoad(CommandSender sender, String fileName) {
 		StorageProvider storageProvider = plugin.getStorageProvider();
 		Locale locale = plugin.getLang().getLocale(sender);
-		if (storageProvider != null) {
-			File file = new File(plugin.getDataFolder() + "/backups/" + fileName);
-			if (file.exists()) {
-				if (file.getName().endsWith(".yml")) {
-					// Require player to double type command
-					if (sender instanceof Player) {
-						PlayerData playerData = plugin.getPlayerManager().getPlayerData((Player) sender);
-						if (playerData == null) return;
-						Object typed = playerData.getMetadata().get("backup_command");
-						if (typed instanceof String) {
-							String typedFile = (String) typed;
-							if (typedFile.equals(file.getName())) {
-								sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_LOADING, locale));
-								storageProvider.loadBackup(YamlConfiguration.loadConfiguration(file), sender);
-								playerData.getMetadata().remove("backup_command");
-							} else {
-								backupLoadConfirm(playerData, sender, file);
-							}
+		File file = new File(plugin.getDataFolder() + "/backups/" + fileName);
+		if (file.exists()) {
+			if (file.getName().endsWith(".yml")) {
+				// Require player to double type command
+				if (sender instanceof Player) {
+					PlayerData playerData = plugin.getPlayerManager().getPlayerData((Player) sender);
+					if (playerData == null) return;
+					Object typed = playerData.getMetadata().get("backup_command");
+					if (typed instanceof String) {
+						String typedFile = (String) typed;
+						if (typedFile.equals(file.getName())) {
+							sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_LOADING, locale));
+							storageProvider.loadBackup(YamlConfiguration.loadConfiguration(file), sender);
+							playerData.getMetadata().remove("backup_command");
 						} else {
 							backupLoadConfirm(playerData, sender, file);
 						}
 					} else {
-						sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_LOADING, locale));
-						storageProvider.loadBackup(YamlConfiguration.loadConfiguration(file), sender);
+						backupLoadConfirm(playerData, sender, file);
 					}
 				} else {
-					sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_MUST_BE_YAML, locale));
+					sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_LOADING, locale));
+					storageProvider.loadBackup(YamlConfiguration.loadConfiguration(file), sender);
 				}
-			} else { // If file does not exist
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_FILE_NOT_FOUND, locale));
+			} else {
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_MUST_BE_YAML, locale));
 			}
 		}
 	}

--- a/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
+++ b/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
@@ -128,7 +128,7 @@ public class SkillsCommand extends BaseCommand {
 	@CommandPermission("aureliumskills.top")
 	@Description("Shows the top players in a skill")
 	@Syntax("Usage: /sk top <page> or /sk top [skill] <page>")
-	public void onTop(CommandSender sender, String [] args) {
+	public void onTop(CommandSender sender, String[] args) {
 		Locale locale = plugin.getLang().getLocale(sender);
 		if (args.length == 0) {
 			List<SkillValue> lb = plugin.getLeaderboardManager().getPowerLeaderboard(1, 10);

--- a/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
+++ b/src/main/java/com/archyx/aureliumskills/commands/SkillsCommand.java
@@ -61,12 +61,10 @@ public class SkillsCommand extends BaseCommand {
 		if (plugin.getPlayerManager().hasPlayerData(player)) {
 			plugin.getMenuManager().openMenu(player, "skills");
 		} else {
-			String m = Lang.getMessage(CommandMessage.NO_PROFILE, Lang.getDefaultLanguage());
-			assert (m != null);
-			player.sendMessage(m);
+			player.sendMessage(Lang.getMessage(CommandMessage.NO_PROFILE, Lang.getDefaultLanguage()));
 		}
 	}
-	
+
 	@Subcommand("xp add")
 	@CommandCompletion("@players @skills")
 	@CommandPermission("aureliumskills.xp.add")
@@ -76,9 +74,7 @@ public class SkillsCommand extends BaseCommand {
 		if (OptionL.isEnabled(skill)) {
 			plugin.getLeveler().addXp(player, skill, amount);
 			if (!silent) {
-				String m = Lang.getMessage(CommandMessage.XP_ADD, locale);
-				assert (m != null);
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_ADD, locale).replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 			}
 		} else {
 			sender.sendMessage(AureliumSkills.getPrefix(locale) + ChatColor.YELLOW + Lang.getMessage(CommandMessage.UNKNOWN_SKILL, locale));
@@ -94,9 +90,7 @@ public class SkillsCommand extends BaseCommand {
 		if (OptionL.isEnabled(skill)) {
 			plugin.getLeveler().setXp(player, skill, amount);
 			if (!silent) {
-				String m = Lang.getMessage(CommandMessage.XP_SET, locale);
-				assert (m != null);
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_SET, locale).replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 			}
 		} else {
 			sender.sendMessage(AureliumSkills.getPrefix(locale) + ChatColor.YELLOW + Lang.getMessage(CommandMessage.UNKNOWN_SKILL, locale));
@@ -115,15 +109,11 @@ public class SkillsCommand extends BaseCommand {
 			if (playerData.getSkillXp(skill) - amount >= 0) {
 				plugin.getLeveler().setXp(player, skill, playerData.getSkillXp(skill) - amount);
 				if (!silent) {
-					String m = Lang.getMessage(CommandMessage.XP_REMOVE, locale);
-					assert (m != null);
-					sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+					sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_REMOVE, locale).replace("{amount}", String.valueOf(amount)).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 				}
 			} else {
 				if (!silent) {
-					String m = Lang.getMessage(CommandMessage.XP_REMOVE, locale);
-					assert (m != null);
-					sender.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{amount}", String.valueOf(playerData.getSkillXp(skill))).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
+					sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.XP_REMOVE, locale).replace("{amount}", String.valueOf(playerData.getSkillXp(skill))).replace("{skill}", skill.getDisplayName(locale)).replace("{player}", player.getName()));
 				}
 				plugin.getLeveler().setXp(player, skill, 0);
 			}
@@ -142,14 +132,10 @@ public class SkillsCommand extends BaseCommand {
 		Locale locale = plugin.getLang().getLocale(sender);
 		if (args.length == 0) {
 			List<SkillValue> lb = plugin.getLeaderboardManager().getPowerLeaderboard(1, 10);
-			String m = Lang.getMessage(CommandMessage.TOP_POWER_HEADER, locale);
-			assert (m != null);
-			sender.sendMessage(m);
+			sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_HEADER, locale));
 			for (SkillValue skillValue : lb) {
 				String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-				m = Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale);
-				assert (null != m);
-				sender.sendMessage(m
+				sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale)
 						.replace("{rank}", String.valueOf(lb.indexOf(skillValue) + 1))
 						.replace("{player}", name != null ? name : "?")
 						.replace("{level}", String.valueOf(skillValue.getLevel())));
@@ -158,22 +144,16 @@ public class SkillsCommand extends BaseCommand {
 		else if (args.length == 1) {
 			if (args[0].equalsIgnoreCase("average")) {
 				List<SkillValue> lb = plugin.getLeaderboardManager().getAverageLeaderboard(1, 10);
-				String m = Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER, locale);
-				assert (m != null);
-				sender.sendMessage(m);
+				sender.sendMessage(Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER, locale));
 				sendLeaderboardEntries(sender, locale, lb);
 			} else {
 				try {
 					int page = Integer.parseInt(args[0]);
 					List<SkillValue> lb = plugin.getLeaderboardManager().getPowerLeaderboard(page, 10);
-					String m = Lang.getMessage(CommandMessage.TOP_POWER_HEADER_PAGE, locale);
-					assert (null != m);
-					sender.sendMessage(m.replace("{page}", String.valueOf(page)));
+					sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_HEADER_PAGE, locale).replace("{page}", String.valueOf(page)));
 					for (SkillValue skillValue : lb) {
 						String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-						m = Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale);
-						assert (null != m);
-						sender.sendMessage(m
+						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_POWER_ENTRY, locale)
 								.replace("{rank}", String.valueOf((page - 1) * 10 + lb.indexOf(skillValue) + 1))
 								.replace("{player}", name != null ? name : "?")
 								.replace("{level}", String.valueOf(skillValue.getLevel())));
@@ -182,22 +162,16 @@ public class SkillsCommand extends BaseCommand {
 					Skill skill = plugin.getSkillRegistry().getSkill(args[0]);
 					if (skill != null) {
 						List<SkillValue> lb = plugin.getLeaderboardManager().getLeaderboard(skill, 1, 10);
-						String m = Lang.getMessage(CommandMessage.TOP_SKILL_HEADER, locale);
-						assert (null != m);
-						sender.sendMessage(m.replace("{skill}", skill.getDisplayName(locale)));
+						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_HEADER, locale).replace("{skill}", skill.getDisplayName(locale)));
 						for (SkillValue skillValue : lb) {
 							String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-							m = Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale);
-							assert (null != m);
-							sender.sendMessage(m
+							sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale)
 									.replace("{rank}", String.valueOf(lb.indexOf(skillValue) + 1))
 									.replace("{player}", name != null ? name : "?")
 									.replace("{level}", String.valueOf(skillValue.getLevel())));
 						}
 					} else {
-						String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
-						assert (m != null);
-						sender.sendMessage(m);
+						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
 					}
 				}
 			}
@@ -207,14 +181,11 @@ public class SkillsCommand extends BaseCommand {
 				try {
 					int page = Integer.parseInt(args[1]);
 					List<SkillValue> lb = plugin.getLeaderboardManager().getAverageLeaderboard(page, 10);
-					String m = TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER_PAGE, locale), "{page}", String.valueOf(page));
-					assert (m != null);
-					sender.sendMessage(m);
+					sender.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_HEADER_PAGE, locale),
+							"{page}", String.valueOf(page)));
 					sendLeaderboardEntries(sender, locale, lb);
 				} catch (Exception e) {
-					String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
-					assert (m != null);
-					sender.sendMessage(m);
+					sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
 				}
 			} else {
 				Skill skill = plugin.getSkillRegistry().getSkill(args[0]);
@@ -222,27 +193,19 @@ public class SkillsCommand extends BaseCommand {
 					try {
 						int page = Integer.parseInt(args[1]);
 						List<SkillValue> lb = plugin.getLeaderboardManager().getLeaderboard(skill, page, 10);
-						String m = Lang.getMessage(CommandMessage.TOP_SKILL_HEADER_PAGE, locale);
-						assert (null != m);
-						sender.sendMessage(m.replace("{page}", String.valueOf(page)).replace("{skill}", skill.getDisplayName(locale)));
+						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_HEADER_PAGE, locale).replace("{page}", String.valueOf(page)).replace("{skill}", skill.getDisplayName(locale)));
 						for (SkillValue skillValue : lb) {
 							String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-							m = Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale);
-							assert (null != m);
-							sender.sendMessage(m
+							sender.sendMessage(Lang.getMessage(CommandMessage.TOP_SKILL_ENTRY, locale)
 									.replace("{rank}", String.valueOf((page - 1) * 10 + lb.indexOf(skillValue) + 1))
 									.replace("{player}", name != null ? name : "?")
 									.replace("{level}", String.valueOf(skillValue.getLevel())));
 						}
 					} catch (Exception e) {
-						String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
-						assert (m != null);
-						sender.sendMessage(m);
+						sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
 					}
 				} else {
-					String m = Lang.getMessage(CommandMessage.TOP_USAGE, locale);
-					assert (m != null);
-					sender.sendMessage(m);
+					sender.sendMessage(Lang.getMessage(CommandMessage.TOP_USAGE, locale));
 				}
 			}
 		}
@@ -251,14 +214,10 @@ public class SkillsCommand extends BaseCommand {
 	private void sendLeaderboardEntries(CommandSender sender, Locale locale, List<SkillValue> lb) {
 		for (SkillValue skillValue : lb) {
 			String name = Bukkit.getOfflinePlayer(skillValue.getId()).getName();
-			String m = TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_ENTRY, locale),
+			sender.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.TOP_AVERAGE_ENTRY, locale),
 					"{rank}", String.valueOf(lb.indexOf(skillValue) + 1),
 					"{player}", name != null ? name : "?",
-					"{level}", NumberUtil.format2(skillValue.getXp()));
-			
-			assert (null != m);
-			
-			sender.sendMessage(m);
+					"{level}", NumberUtil.format2(skillValue.getXp())));
 		}
 	}
 
@@ -335,20 +294,13 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Shows your skill rankings")
 	public void onRank(Player player) {
 		Locale locale = plugin.getLang().getLocale(player);
-		String m;
-		m = Lang.getMessage(CommandMessage.RANK_HEADER, locale);
-		assert (m != null);
-		player.sendMessage(m);
-		m = Lang.getMessage(CommandMessage.RANK_POWER, locale);
-		assert (m != null);
-		player.sendMessage(m
+		player.sendMessage(Lang.getMessage(CommandMessage.RANK_HEADER, locale));
+		player.sendMessage(Lang.getMessage(CommandMessage.RANK_POWER, locale)
 				.replace("{rank}", String.valueOf(plugin.getLeaderboardManager().getPowerRank(player.getUniqueId())))
 				.replace("{total}", String.valueOf(plugin.getLeaderboardManager().getPowerLeaderboard().size())));
 		for (Skill skill : plugin.getSkillRegistry().getSkills()) {
 			if (OptionL.isEnabled(skill)) {
-				m = Lang.getMessage(CommandMessage.RANK_ENTRY, locale);
-				assert (null != m);
-				player.sendMessage(m
+				player.sendMessage(Lang.getMessage(CommandMessage.RANK_ENTRY, locale)
 						.replace("{skill}", String.valueOf(skill.getDisplayName(locale)))
 						.replace("{rank}", String.valueOf(plugin.getLeaderboardManager().getSkillRank(skill, player.getUniqueId())))
 						.replace("{total}", String.valueOf(plugin.getLeaderboardManager().getLeaderboard(skill).size())));
@@ -367,14 +319,10 @@ public class SkillsCommand extends BaseCommand {
 			if (playerData == null) return;
 			playerData.setLocale(locale);
 			plugin.getCommandManager().setPlayerLocale(player, locale);
-			String m = Lang.getMessage(CommandMessage.LANG_SET, locale);
-			assert (null != m);
-			player.sendMessage(AureliumSkills.getPrefix(locale) + m.replace("{lang}", Lang.getDefinedLanguages().get(locale)));
+			player.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.LANG_SET, locale).replace("{lang}", Lang.getDefinedLanguages().get(locale)));
 		}
 		else {
-			String m = Lang.getMessage(CommandMessage.LANG_NOT_FOUND, plugin.getLang().getLocale(player));
-			assert (null != m);
-			player.sendMessage(AureliumSkills.getPrefix(locale) + m);
+			player.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.LANG_NOT_FOUND, plugin.getLang().getLocale(player)));
 		}
 	}
 	
@@ -404,9 +352,8 @@ public class SkillsCommand extends BaseCommand {
 				plugin.getLeveler().applyLevelUpCommands(player, skill, oldLevel, level);
 				// Reload items and armor to check for newly met requirements
 				this.plugin.getModifierManager().reloadPlayer(player);
-				String m = Lang.getMessage(CommandMessage.SKILL_SETLEVEL_SET, locale);
-				assert (null != m);
-				sender.sendMessage((AureliumSkills.getPrefix(locale) + m.replace("{skill}", skill.getDisplayName(locale)))
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_SETLEVEL_SET, locale)
+						.replace("{skill}", skill.getDisplayName(locale))
 						.replace("{level}", String.valueOf(level))
 						.replace("{player}", player.getName()));
 			} else {
@@ -440,9 +387,7 @@ public class SkillsCommand extends BaseCommand {
 			}
 			plugin.getLeveler().updateStats(player);
 			plugin.getLeveler().updatePermissions(player);
-			String m = Lang.getMessage(CommandMessage.SKILL_SETALL_SET, locale);
-			assert (null != m);
-			sender.sendMessage(AureliumSkills.getPrefix(locale) + m
+			sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_SETALL_SET, locale)
 					.replace("{level}", String.valueOf(level))
 					.replace("{player}", player.getName()));
 		} else {
@@ -457,16 +402,14 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Resets all skills or a specific skill to level 1 for a player.")
 	public void onSkillReset(CommandSender sender, @Flags("other") Player player, @Optional Skill skill) {
 		Locale locale = plugin.getLang().getLocale(sender);
+		PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
+		if (playerData == null) return;
 		if (skill != null) {
 			if (OptionL.isEnabled(skill)) {
-				PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-				if (playerData == null) return;
 				resetPlayerSkills(player, playerData, skill);
 				// Reload items and armor to check for newly met requirements
 				this.plugin.getModifierManager().reloadPlayer(player);
-				String m = Lang.getMessage(CommandMessage.SKILL_RESET_RESET_SKILL, locale);
-				assert (null != m);
-				sender.sendMessage(AureliumSkills.getPrefix(locale) + m
+				sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_RESET_RESET_SKILL, locale)
 						.replace("{skill}", skill.getDisplayName(locale))
 						.replace("{player}", player.getName()));
 			} else {
@@ -474,14 +417,11 @@ public class SkillsCommand extends BaseCommand {
 			}
 		}
 		else {
-			PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-			if (playerData == null) return;
 			for (Skill s : plugin.getSkillRegistry().getSkills()) {
+			playerData.clearInvalidItems();
 				resetPlayerSkills(player, playerData, s);
 			}
-			String m = Lang.getMessage(CommandMessage.SKILL_RESET_RESET_ALL, locale);
-			assert (m != null);
-			sender.sendMessage(AureliumSkills.getPrefix(locale) + m
+			sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.SKILL_RESET_RESET_ALL, locale)
 					.replace("{player}", player.getName()));
 		}
 	}
@@ -598,12 +538,16 @@ public class SkillsCommand extends BaseCommand {
 				message = new StringBuilder(StatModifier.applyPlaceholders(Lang.getMessage(CommandMessage.MODIFIER_LIST_ALL_STATS_HEADER, locale), player));
 				for (String key : playerData.getStatModifiers().keySet()) {
 					StatModifier modifier = playerData.getStatModifiers().get(key);
+					if (modifier == null)
+						throw new IllegalStateException("Invalid stat modifier index key: " + key);
 					message.append("\n").append(StatModifier.applyPlaceholders(Lang.getMessage(CommandMessage.MODIFIER_LIST_ALL_STATS_ENTRY, locale), modifier, player, locale));
 				}
 			} else {
 				message = new StringBuilder(StatModifier.applyPlaceholders(Lang.getMessage(CommandMessage.MODIFIER_LIST_ONE_STAT_HEADER, locale), stat, player, locale));
 				for (String key : playerData.getStatModifiers().keySet()) {
 					StatModifier modifier = playerData.getStatModifiers().get(key);
+					if (modifier == null)
+						throw new IllegalStateException("Invalid stat modifier index key: " + key);
 					if (modifier.getStat() == stat) {
 						message.append("\n").append(StatModifier.applyPlaceholders(Lang.getMessage(CommandMessage.MODIFIER_LIST_ONE_STAT_ENTRY, locale), modifier, player, locale));
 					}
@@ -648,9 +592,12 @@ public class SkillsCommand extends BaseCommand {
 					toRemove.add(key);
 					removed++;
 				}
-				else if (playerData.getStatModifiers().get(key).getStat() == stat) {
-					toRemove.add(key);
-					removed++;
+				else {
+					StatModifier modifier = playerData.getStatModifiers().get(key);
+					if (modifier.getStat() == stat) {
+						toRemove.add(key);
+						removed++;
+					}
 				}
 			}
 			for (String key : toRemove) {
@@ -873,16 +820,12 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Lists the item requirements on the item held.")
 	public void onItemRequirementList(@Flags("itemheld") Player player) {
 		Locale locale = plugin.getLang().getLocale(player);
-		String m = Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_HEADER, locale);
-		assert (m != null);
-		player.sendMessage(m);
+		player.sendMessage(Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_HEADER, locale));
 		Requirements requirements = new Requirements(plugin);
 		for (Map.Entry<Skill, Integer> entry : requirements.getRequirements(ModifierType.ITEM, player.getInventory().getItemInMainHand()).entrySet()) {
-			m = TextUtil.replace(Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_ENTRY, locale),
+			player.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.ITEM_REQUIREMENT_LIST_ENTRY, locale),
 					"{skill}", entry.getKey().getDisplayName(locale),
-					"{level}", String.valueOf(entry.getValue()));
-			assert (m != null);
-			player.sendMessage(m);
+					"{level}", String.valueOf(entry.getValue())));
 		}
 	}
 
@@ -948,16 +891,12 @@ public class SkillsCommand extends BaseCommand {
 	@Description("Lists the armor requirements on the item held.")
 	public void onArmorRequirementList(@Flags("itemheld") Player player) {
 		Locale locale = plugin.getLang().getLocale(player);
-		String m = Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_HEADER, locale);
-		assert (m != null);
-		player.sendMessage(m);
+		player.sendMessage(Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_HEADER, locale));
 		Requirements requirements = new Requirements(plugin);
 		for (Map.Entry<Skill, Integer> entry : requirements.getRequirements(ModifierType.ARMOR, player.getInventory().getItemInMainHand()).entrySet()) {
-			m = TextUtil.replace(Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_ENTRY, locale),
+			player.sendMessage(TextUtil.replace(Lang.getMessage(CommandMessage.ARMOR_REQUIREMENT_LIST_ENTRY, locale),
 					"{skill}", entry.getKey().getDisplayName(locale),
-					"{level}", String.valueOf(entry.getValue()));
-			assert (m != null);
-			player.sendMessage(m);
+					"{level}", String.valueOf(entry.getValue())));
 		}
 	}
 
@@ -1119,16 +1058,12 @@ public class SkillsCommand extends BaseCommand {
 						PlayerData playerData = plugin.getPlayerManager().getPlayerData((Player) sender);
 						if (playerData == null) return;
 						Object typed = playerData.getMetadata().get("backup_command");
-						if (typed != null) {
-							if (typed instanceof String) {
-								String typedFile = (String) typed;
-								if (typedFile.equals(file.getName())) {
-									sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_LOADING, locale));
-									storageProvider.loadBackup(YamlConfiguration.loadConfiguration(file), sender);
-									playerData.getMetadata().remove("backup_command");
-								} else {
-									backupLoadConfirm(playerData, sender, file);
-								}
+						if (typed instanceof String) {
+							String typedFile = (String) typed;
+							if (typedFile.equals(file.getName())) {
+								sender.sendMessage(AureliumSkills.getPrefix(locale) + Lang.getMessage(CommandMessage.BACKUP_LOAD_LOADING, locale));
+								storageProvider.loadBackup(YamlConfiguration.loadConfiguration(file), sender);
+								playerData.getMetadata().remove("backup_command");
 							} else {
 								backupLoadConfirm(playerData, sender, file);
 							}

--- a/src/main/java/com/archyx/aureliumskills/configuration/Option.java
+++ b/src/main/java/com/archyx/aureliumskills/configuration/Option.java
@@ -1,6 +1,5 @@
 package com.archyx.aureliumskills.configuration;
 
-
 public enum Option {
 
     // Mysql Options

--- a/src/main/java/com/archyx/aureliumskills/configuration/OptionL.java
+++ b/src/main/java/com/archyx/aureliumskills/configuration/OptionL.java
@@ -99,27 +99,45 @@ public class OptionL {
     }
 
     public static double getDouble(Option option) {
-        return options.get(option).asDouble();
+        OptionValue value = options.get(option);
+        if (value == null)
+            throw new IllegalStateException("Invalid or missing configuration option: " + option.getPath());
+        return value.asDouble();
     }
 
     public static int getInt(Option option) {
-        return options.get(option).asInt();
+        OptionValue value = options.get(option);
+        if (value == null)
+            throw new IllegalStateException("Invalid or missing configuration option: " + option.getPath());
+        return value.asInt();
     }
 
     public static boolean getBoolean(Option option) {
-        return options.get(option).asBoolean();
+        OptionValue value = options.get(option);
+        if (value == null)
+            throw new IllegalStateException("Invalid or missing configuration option: " + option.getPath());
+        return value.asBoolean();
     }
 
     public static String getString(Option option) {
-        return options.get(option).asString();
+        OptionValue value = options.get(option);
+        if (value == null)
+            throw new IllegalStateException("Invalid or missing configuration option: " + option.getPath());
+        return value.asString();
     }
 
     public static List<String> getList(Option option) {
-        return options.get(option).asList();
+        OptionValue value = options.get(option);
+        if (value == null)
+            throw new IllegalStateException("Invalid or missing configuration option: " + option.getPath());
+        return value.asList();
     }
 
     public static ChatColor getColor(Option option) {
-        return options.get(option).asColor();
+        OptionValue value = options.get(option);
+        if (value == null)
+            throw new IllegalStateException("Invalid or missing configuration option: " + option.getPath());
+        return value.asColor();
     }
 
     public static boolean isEnabled(Skill skill) {

--- a/src/main/java/com/archyx/aureliumskills/data/AbilityData.java
+++ b/src/main/java/com/archyx/aureliumskills/data/AbilityData.java
@@ -1,7 +1,6 @@
 package com.archyx.aureliumskills.data;
 
 import com.archyx.aureliumskills.ability.AbstractAbility;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +19,6 @@ public class AbilityData {
         return ability;
     }
 
-    @Nullable
     public Object getData(String key) {
         return data.get(key);
     }

--- a/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
+++ b/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
@@ -69,7 +69,7 @@ public class PlayerData {
     }
 
     public int getSkillLevel(Skill skill) {
-        return skillLevels.getOrDefault(skill, 1);
+        return Objects.requireNonNullElse(skillLevels.get(skill), 1);
     }
 
     public void setSkillLevel(Skill skill, int level) {
@@ -77,7 +77,7 @@ public class PlayerData {
     }
 
     public double getSkillXp(Skill skill) {
-        return skillXp.getOrDefault(skill, 0.0);
+        return Objects.requireNonNullElse(skillXp.get(skill), 0.0);
     }
 
     public void setSkillXp(Skill skill, double xp) {
@@ -89,7 +89,7 @@ public class PlayerData {
     }
 
     public double getStatLevel(Stat stat) {
-        return statLevels.getOrDefault(stat, 0.0);
+        return Objects.requireNonNullElse(statLevels.get(stat), 0.0);
     }
 
     public void setStatLevel(Stat stat, double level) {
@@ -125,7 +125,7 @@ public class PlayerData {
         // Removes if already existing
         if (statModifiers.containsKey(modifier.getName())) {
             StatModifier oldModifier = statModifiers.get(modifier.getName());
-            if (oldModifier.getStat() == modifier.getStat() && oldModifier.getValue() == modifier.getValue()) {
+            if (oldModifier != null && oldModifier.getStat() == modifier.getStat() && oldModifier.getValue() == modifier.getValue()) {
                 return;
             }
             removeStatModifier(modifier.getName());
@@ -286,9 +286,10 @@ public class PlayerData {
     public double getTotalMultiplier(@Nullable Skill skill) {
         double totalMultiplier = 0.0;
         for (Multiplier multiplier : getMultipliers().values()) {
+            Skill multiplierSkill = multiplier.getSkill();
             if (multiplier.isGlobal()) {
                 totalMultiplier += multiplier.getValue();
-            } else if (multiplier.getSkill() != null && multiplier.getSkill().equals(skill)) {
+            } else if (multiplierSkill != null && multiplierSkill.equals(skill)) {
                 totalMultiplier += multiplier.getValue();
             }
         }

--- a/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
+++ b/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
@@ -69,7 +69,8 @@ public class PlayerData {
     }
 
     public int getSkillLevel(Skill skill) {
-        return Objects.requireNonNullElse(skillLevels.get(skill), 1);
+        Integer level = skillLevels.get(skill);
+        return level != null ? level : 1;
     }
 
     public void setSkillLevel(Skill skill, int level) {
@@ -77,7 +78,8 @@ public class PlayerData {
     }
 
     public double getSkillXp(Skill skill) {
-        return Objects.requireNonNullElse(skillXp.get(skill), 0.0);
+        Double xp = skillXp.get(skill);
+        return xp != null ? xp : 0.0;
     }
 
     public void setSkillXp(Skill skill, double xp) {
@@ -89,7 +91,8 @@ public class PlayerData {
     }
 
     public double getStatLevel(Stat stat) {
-        return Objects.requireNonNullElse(statLevels.get(stat), 0.0);
+        Double level = statLevels.get(stat);
+        return level != null ? level : 0.0;
     }
 
     public void setStatLevel(Stat stat, double level) {

--- a/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
+++ b/src/main/java/com/archyx/aureliumskills/data/PlayerData.java
@@ -15,8 +15,6 @@ import com.archyx.aureliumskills.stats.Stat;
 import com.archyx.aureliumskills.stats.Stats;
 import com.archyx.aureliumskills.util.misc.KeyIntPair;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -128,7 +126,9 @@ public class PlayerData {
         // Removes if already existing
         if (statModifiers.containsKey(modifier.getName())) {
             StatModifier oldModifier = statModifiers.get(modifier.getName());
-            if (oldModifier != null && oldModifier.getStat() == modifier.getStat() && oldModifier.getValue() == modifier.getValue()) {
+            if (oldModifier == null)
+                throw new IllegalStateException("Invalid modifier stat index key: " + modifier.getName());
+            if (oldModifier.getStat() == modifier.getStat() && oldModifier.getValue() == modifier.getValue()) {
                 return;
             }
             removeStatModifier(modifier.getName());
@@ -152,7 +152,10 @@ public class PlayerData {
     public boolean removeStatModifier(String name, boolean reload) {
         StatModifier modifier = statModifiers.get(name);
         if (modifier == null) return false;
-        setStatLevel(modifier.getStat(), statLevels.get(modifier.getStat()) - modifier.getValue());
+        Double level = statLevels.get(modifier.getStat());
+        if (level == null)
+            throw new IllegalStateException("Invalid modifier stat index key: " + modifier.getStat());
+        setStatLevel(modifier.getStat(), level - modifier.getValue());
         statModifiers.remove(name);
         // Reloads stats
         if (reload) {
@@ -266,7 +269,7 @@ public class PlayerData {
         }
     }
 
-    public void setUnclaimedItems(@NotNull List<KeyIntPair> unclaimedItems) {
+    public void setUnclaimedItems(List<KeyIntPair> unclaimedItems) {
         this.unclaimedItems = unclaimedItems;
     }
 
@@ -286,7 +289,7 @@ public class PlayerData {
         this.shouldSave = shouldSave;
     }
 
-    public double getTotalMultiplier(@Nullable Skill skill) {
+    public double getTotalMultiplier(Skill skill) {
         double totalMultiplier = 0.0;
         for (Multiplier multiplier : getMultipliers().values()) {
             Skill multiplierSkill = multiplier.getSkill();

--- a/src/main/java/com/archyx/aureliumskills/data/PlayerDataLoadEvent.java
+++ b/src/main/java/com/archyx/aureliumskills/data/PlayerDataLoadEvent.java
@@ -2,7 +2,6 @@ package com.archyx.aureliumskills.data;
 
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import org.jetbrains.annotations.NotNull;
 
 public class PlayerDataLoadEvent extends Event {
 
@@ -18,7 +17,6 @@ public class PlayerDataLoadEvent extends Event {
         return playerData;
     }
 
-    @NotNull
     @Override
     public HandlerList getHandlers() {
         return handlers;

--- a/src/main/java/com/archyx/aureliumskills/data/PlayerManager.java
+++ b/src/main/java/com/archyx/aureliumskills/data/PlayerManager.java
@@ -6,8 +6,6 @@ import com.archyx.aureliumskills.configuration.OptionL;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,17 +23,15 @@ public class PlayerManager {
         }
     }
 
-    @Nullable
     public PlayerData getPlayerData(Player player) {
         return playerData.get(player.getUniqueId());
     }
 
-    @Nullable
     public PlayerData getPlayerData(UUID id) {
         return this.playerData.get(id);
     }
 
-    public void addPlayerData(@NotNull PlayerData playerData) {
+    public void addPlayerData(PlayerData playerData) {
         this.playerData.put(playerData.getPlayer().getUniqueId(), playerData);
     }
 

--- a/src/main/java/com/archyx/aureliumskills/data/backup/YamlBackup.java
+++ b/src/main/java/com/archyx/aureliumskills/data/backup/YamlBackup.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Locale;
+import java.util.Objects;
 
 public class YamlBackup extends BackupProvider {
 
@@ -67,7 +68,7 @@ public class YamlBackup extends BackupProvider {
             String message = AureliumSkills.getPrefix(locale) + TextUtil.replace(Lang.getMessage(CommandMessage.BACKUP_SAVE_SAVED, locale)
                     , "{type}", "Yaml", "{file}", backupFile.getName());
             if (sender instanceof ConsoleCommandSender) {
-                message = ChatColor.stripColor(message);
+                message = Objects.requireNonNullElse(ChatColor.stripColor(message), "");
             }
             sender.sendMessage(message);
         } catch (Exception e) {

--- a/src/main/java/com/archyx/aureliumskills/data/backup/YamlBackup.java
+++ b/src/main/java/com/archyx/aureliumskills/data/backup/YamlBackup.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Locale;
-import java.util.Objects;
 
 public class YamlBackup extends BackupProvider {
 
@@ -69,7 +68,8 @@ public class YamlBackup extends BackupProvider {
                     , "{type}", "Yaml", "{file}", backupFile.getName());
             if (sender instanceof ConsoleCommandSender) {
                 String m = ChatColor.stripColor(message);
-                message = m != null ? m : "";
+                assert (null != m);
+                message = m;
             }
             sender.sendMessage(message);
         } catch (Exception e) {

--- a/src/main/java/com/archyx/aureliumskills/data/backup/YamlBackup.java
+++ b/src/main/java/com/archyx/aureliumskills/data/backup/YamlBackup.java
@@ -68,7 +68,8 @@ public class YamlBackup extends BackupProvider {
             String message = AureliumSkills.getPrefix(locale) + TextUtil.replace(Lang.getMessage(CommandMessage.BACKUP_SAVE_SAVED, locale)
                     , "{type}", "Yaml", "{file}", backupFile.getName());
             if (sender instanceof ConsoleCommandSender) {
-                message = Objects.requireNonNullElse(ChatColor.stripColor(message), "");
+                String m = ChatColor.stripColor(message);
+                message = m != null ? m : "";
             }
             sender.sendMessage(message);
         } catch (Exception e) {

--- a/src/main/java/com/archyx/aureliumskills/data/storage/MySqlStorageProvider.java
+++ b/src/main/java/com/archyx/aureliumskills/data/storage/MySqlStorageProvider.java
@@ -98,6 +98,7 @@ public class MySqlStorageProvider extends StorageProvider {
                         String statModifiers = result.getString("STAT_MODIFIERS");
                         if (statModifiers != null) {
                             JsonArray jsonModifiers = new Gson().fromJson(statModifiers, JsonArray.class);
+                            assert (null != jsonModifiers);
                             for (JsonElement modifierElement : jsonModifiers.getAsJsonArray()) {
                                 JsonObject modifierObject = modifierElement.getAsJsonObject();
                                 String name = modifierObject.get("name").getAsString();
@@ -105,8 +106,10 @@ public class MySqlStorageProvider extends StorageProvider {
                                 double value = modifierObject.get("value").getAsDouble();
                                 if (name != null && statName != null) {
                                     Stat stat = plugin.getStatRegistry().getStat(statName);
-                                    StatModifier modifier = new StatModifier(name, stat, value);
-                                    playerData.addStatModifier(modifier);
+                                    if (stat != null) {
+                                        StatModifier modifier = new StatModifier(name, stat, value);
+                                        playerData.addStatModifier(modifier);
+                                    }
                                 }
                             }
                         }
@@ -120,6 +123,7 @@ public class MySqlStorageProvider extends StorageProvider {
                         String abilityData = result.getString("ABILITY_DATA");
                         if (abilityData != null) {
                             JsonObject jsonAbilityData = new Gson().fromJson(abilityData, JsonObject.class);
+                            assert (null != jsonAbilityData);
                             for (Map.Entry<String, JsonElement> abilityEntry : jsonAbilityData.entrySet()) {
                                 String abilityName = abilityEntry.getKey();
                                 AbstractAbility ability = AbstractAbility.valueOf(abilityName.toUpperCase(Locale.ROOT));
@@ -246,7 +250,9 @@ public class MySqlStorageProvider extends StorageProvider {
                         statement.setInt(index++, playerData.getSkillLevel(skill));
                         statement.setDouble(index++, playerData.getSkillXp(skill));
                     }
-                    statement.setString(index++, playerData.getLocale().toString());
+                    Locale locale = playerData.getLocale();
+                    assert (null != locale);
+                    statement.setString(index++, locale.toString());
                     // Build stat modifiers json
                     StringBuilder modifiersJson = new StringBuilder();
                     if (playerData.getStatModifiers().size() > 0) {

--- a/src/main/java/com/archyx/aureliumskills/data/storage/StorageProvider.java
+++ b/src/main/java/com/archyx/aureliumskills/data/storage/StorageProvider.java
@@ -15,6 +15,7 @@ import com.archyx.aureliumskills.skills.Skills;
 import com.archyx.aureliumskills.stats.Stat;
 import com.archyx.aureliumskills.stats.StatLeveler;
 import com.archyx.aureliumskills.stats.Stats;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -62,9 +63,14 @@ public abstract class StorageProvider {
         }
         // Apply to object if in memory
         for (Skill skill : Skills.values()) {
-            int level = levels.get(skill);
+            Integer level = levels.get(skill);
+            if (level == null)
+                throw new IllegalStateException("Invalid level for skill index key: " + skill.name());
             playerData.setSkillLevel(skill, level);
-            playerData.setSkillXp(skill, xpLevels.get(skill));
+            Double xpLevel = xpLevels.get(skill);
+            if (xpLevel == null)
+                throw new IllegalStateException("Invalid experience level for skill index key: " + skill.name());
+            playerData.setSkillXp(skill, xpLevel);
             // Add stat levels
             plugin.getRewardManager().getRewardTable(skill).applyStats(playerData, level);
         }
@@ -106,8 +112,10 @@ public abstract class StorageProvider {
                 double xp = playerData.getSkillXp(skill);
                 // Add to lists
                 SkillValue skillLevel = new SkillValue(id, level, xp);
-                leaderboards.get(skill).add(skillLevel);
-
+                List<SkillValue> skillList = leaderboards.get(skill);
+                if (skillList == null)
+                    throw new IllegalStateException("Invalid skill leaderboard skill index key: " + skill);
+                skillList.add(skillLevel);
                 if (OptionL.isEnabled(skill)) {
                     powerLevel += level;
                     powerXp += xp;

--- a/src/main/java/com/archyx/aureliumskills/data/storage/YamlStorageProvider.java
+++ b/src/main/java/com/archyx/aureliumskills/data/storage/YamlStorageProvider.java
@@ -68,8 +68,10 @@ public class YamlStorageProvider extends StorageProvider {
                             double value = modifierEntry.getDouble("value");
                             if (name != null && statName != null) {
                                 Stat stat = plugin.getStatRegistry().getStat(statName);
-                                StatModifier modifier = new StatModifier(name, stat, value);
-                                playerData.addStatModifier(modifier);
+                                if (stat != null) {
+                                    StatModifier modifier = new StatModifier(name, stat, value);
+                                    playerData.addStatModifier(modifier);
+                                }
                             }
                         }
                     }

--- a/src/main/java/com/archyx/aureliumskills/item/ItemRegistry.java
+++ b/src/main/java/com/archyx/aureliumskills/item/ItemRegistry.java
@@ -5,7 +5,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +31,6 @@ public class ItemRegistry {
         items.remove(key);
     }
 
-    @Nullable
     public ItemStack getItem(String key) {
         ItemStack item = items.get(key);
         if (item != null) {

--- a/src/main/java/com/archyx/aureliumskills/item/ItemRegistryMenuProvider.java
+++ b/src/main/java/com/archyx/aureliumskills/item/ItemRegistryMenuProvider.java
@@ -2,7 +2,6 @@ package com.archyx.aureliumskills.item;
 
 import com.archyx.slate.item.provider.KeyedItemProvider;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 public class ItemRegistryMenuProvider implements KeyedItemProvider {
 
@@ -13,7 +12,7 @@ public class ItemRegistryMenuProvider implements KeyedItemProvider {
     }
 
     @Override
-    public @Nullable ItemStack getItem(String key) {
+    public ItemStack getItem(String key) {
         return itemRegistry.getItem(key);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/item/UnclaimedItemsMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/item/UnclaimedItemsMenu.java
@@ -60,9 +60,7 @@ public class UnclaimedItemsMenu implements InventoryProvider {
                         keyIntPair.setValue(leftoverItem.getAmount());
                         init(player, contents);
                     } else { // All items could not fit
-                        String m = Lang.getMessage(MenuMessage.INVENTORY_FULL, playerData.getLocale());
-                        assert (null != m);
-                        player.sendMessage(m);
+                        player.sendMessage(Lang.getMessage(MenuMessage.INVENTORY_FULL, playerData.getLocale()));
                         player.closeInventory();
                     }
                 }));
@@ -89,9 +87,7 @@ public class UnclaimedItemsMenu implements InventoryProvider {
             } else {
                 lore.add(" ");
             }
-            String t = Lang.getMessage(MenuMessage.CLICK_TO_CLAIM, playerData.getLocale());
-            assert (null != t);
-            lore.add(t);
+            lore.add(Lang.getMessage(MenuMessage.CLICK_TO_CLAIM, playerData.getLocale()));
             meta.setLore(lore);
         }
         displayItem.setItemMeta(meta);

--- a/src/main/java/com/archyx/aureliumskills/item/UnclaimedItemsMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/item/UnclaimedItemsMenu.java
@@ -60,7 +60,9 @@ public class UnclaimedItemsMenu implements InventoryProvider {
                         keyIntPair.setValue(leftoverItem.getAmount());
                         init(player, contents);
                     } else { // All items could not fit
-                        player.sendMessage(Lang.getMessage(MenuMessage.INVENTORY_FULL, playerData.getLocale()));
+                        String m = Lang.getMessage(MenuMessage.INVENTORY_FULL, playerData.getLocale());
+                        assert (null != m);
+                        player.sendMessage(m);
                         player.closeInventory();
                     }
                 }));
@@ -87,7 +89,9 @@ public class UnclaimedItemsMenu implements InventoryProvider {
             } else {
                 lore.add(" ");
             }
-            lore.add(Lang.getMessage(MenuMessage.CLICK_TO_CLAIM, playerData.getLocale()));
+            String t = Lang.getMessage(MenuMessage.CLICK_TO_CLAIM, playerData.getLocale());
+            assert (null != t);
+            lore.add(t);
             meta.setLore(lore);
         }
         displayItem.setItemMeta(meta);

--- a/src/main/java/com/archyx/aureliumskills/lang/Lang.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/Lang.java
@@ -130,7 +130,9 @@ public class Lang implements Listener {
 				MessageKey key = null;
 				// Try to find message key
 				for (MessageKey messageKey : MessageKey.values()) {
-					if (messageKey.getPath().equals(path)) {
+					String keyPath = messageKey.getPath();
+					assert (null != keyPath);
+					if (keyPath.equals(path)) {
 						key = messageKey;
 					}
 				}
@@ -151,7 +153,9 @@ public class Lang implements Listener {
 		}
 		// Check that each message key has a value
 		for (MessageKey key : MessageKey.values()) {
-			String message = config.getString(key.getPath());
+			String path = key.getPath();
+			assert (null != path);
+			String message = config.getString(path);
 			if (message == null && locale.equals(Locale.ENGLISH)) {
 				plugin.getLogger().warning("[" + locale.toLanguageTag() + "] Message with path " + key.getPath() + " not found!");
 			}

--- a/src/main/java/com/archyx/aureliumskills/lang/ManaAbilityMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/ManaAbilityMessage.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 
 public enum ManaAbilityMessage implements MessageKey {
     
+    NONE,
     REPLENISH_NAME,
     REPLENISH_DESC,
     REPLENISH_RAISE,
@@ -59,6 +60,10 @@ public enum ManaAbilityMessage implements MessageKey {
     private final String path;
 
     ManaAbilityMessage() {
+        if (this.name().equals("NONE")) {
+            this.path = "";
+            return;
+        }
         MAbility manaAbility = MAbility.valueOf(this.name().substring(0, this.name().lastIndexOf("_")));
         this.path = "mana_abilities." + manaAbility.name().toLowerCase(Locale.ENGLISH) + "." + this.name().substring(this.name().lastIndexOf("_") + 1).toLowerCase(Locale.ENGLISH);
     }

--- a/src/main/java/com/archyx/aureliumskills/lang/MenuMessage.java
+++ b/src/main/java/com/archyx/aureliumskills/lang/MenuMessage.java
@@ -129,10 +129,14 @@ public enum MenuMessage implements MessageKey {
         } else if (section == 7) {
             this.path = "menus.abilities." + key;
         }
+        else
+            throw new IndexOutOfBoundsException();
     }
 
     @Override
     public String getPath() {
+        assert (null != path);
+        
         return path;
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/leaderboard/LeaderboardManager.java
+++ b/src/main/java/com/archyx/aureliumskills/leaderboard/LeaderboardManager.java
@@ -18,7 +18,10 @@ public class LeaderboardManager {
     }
 
     public List<SkillValue> getLeaderboard(Skill skill) {
-        return skillLeaderboards.get(skill);
+        List<SkillValue> leaderboard = skillLeaderboards.get(skill);
+        if (leaderboard == null)
+            throw new IllegalStateException("Invalid leaderboard skill index key: " + skill.name());
+        return leaderboard;
     }
 
     public void setLeaderboard(Skill skill, List<SkillValue> leaderboard) {
@@ -27,6 +30,8 @@ public class LeaderboardManager {
 
     public List<SkillValue> getLeaderboard(Skill skill, int page, int numPerPage) {
         List<SkillValue> leaderboard = skillLeaderboards.get(skill);
+        if (leaderboard == null)
+            throw new IllegalStateException("Invalid leaderboard skill index key: " + skill.name());
         int from = (Math.max(page, 1) - 1) * numPerPage;
         int to = from + numPerPage;
         return leaderboard.subList(Math.min(from, leaderboard.size()), Math.min(to, leaderboard.size()));
@@ -62,6 +67,8 @@ public class LeaderboardManager {
 
     public int getSkillRank(Skill skill, UUID id) {
         List<SkillValue> leaderboard = skillLeaderboards.get(skill);
+        if (leaderboard == null)
+            throw new IllegalStateException("Invalid leaderboard skill index key: " + skill.name());
         for (SkillValue skillValue : leaderboard) {
             if (skillValue.getId().equals(id)) {
                 return leaderboard.indexOf(skillValue) + 1;

--- a/src/main/java/com/archyx/aureliumskills/leveler/Leveler.java
+++ b/src/main/java/com/archyx/aureliumskills/leveler/Leveler.java
@@ -65,6 +65,7 @@ public class Leveler {
 					multiplier += Double.parseDouble(permission) / 100;
 				} else if (skill != null) { // Skill specific multiplier
 					String skillName = skill.toString().toLowerCase(Locale.ROOT);
+					assert (null != permission);
 					if (permission.startsWith(skillName)) {
 						permission = TextUtil.replace(permission, skillName + ".", "");
 						if (pattern.matcher(permission).matches()) {
@@ -274,6 +275,7 @@ public class Leveler {
 				,"{skill}", skill.getDisplayName(locale)
 				,"{old}", RomanNumber.toRoman(newLevel - 1)
 				,"{new}", RomanNumber.toRoman(newLevel));
+		assert (null != message);
 		if (plugin.isPlaceholderAPIEnabled()) {
 			message = PlaceholderAPI.setPlaceholders(player, message);
 		}
@@ -335,6 +337,7 @@ public class Leveler {
 					"{amount}", nf.format(totalMoney)));
 		}
 		message = TextUtil.replace(message, "{money_reward}", moneyRewardMessage.toString());
+		assert (null != message);
 		return message.replaceAll("(\\u005C\\u006E)|(\\n)", "\n");
 	}
 

--- a/src/main/java/com/archyx/aureliumskills/leveler/Leveler.java
+++ b/src/main/java/com/archyx/aureliumskills/leveler/Leveler.java
@@ -65,7 +65,6 @@ public class Leveler {
 					multiplier += Double.parseDouble(permission) / 100;
 				} else if (skill != null) { // Skill specific multiplier
 					String skillName = skill.toString().toLowerCase(Locale.ROOT);
-					assert (null != permission);
 					if (permission.startsWith(skillName)) {
 						permission = TextUtil.replace(permission, skillName + ".", "");
 						if (pattern.matcher(permission).matches()) {
@@ -159,6 +158,8 @@ public class Leveler {
 		// Reloads modifiers
 		for (String key : playerData.getStatModifiers().keySet()) {
 			StatModifier modifier = playerData.getStatModifiers().get(key);
+			if (modifier == null)
+				throw new IllegalStateException("Invalid stat modifier index key: " + key);
 			playerData.addStatLevel(modifier.getStat(), modifier.getValue());
 		}
 		statLeveler.reloadStat(player, Stats.HEALTH);
@@ -275,7 +276,6 @@ public class Leveler {
 				,"{skill}", skill.getDisplayName(locale)
 				,"{old}", RomanNumber.toRoman(newLevel - 1)
 				,"{new}", RomanNumber.toRoman(newLevel));
-		assert (null != message);
 		if (plugin.isPlaceholderAPIEnabled()) {
 			message = PlaceholderAPI.setPlaceholders(player, message);
 		}
@@ -337,7 +337,6 @@ public class Leveler {
 					"{amount}", nf.format(totalMoney)));
 		}
 		message = TextUtil.replace(message, "{money_reward}", moneyRewardMessage.toString());
-		assert (null != message);
 		return message.replaceAll("(\\u005C\\u006E)|(\\n)", "\n");
 	}
 

--- a/src/main/java/com/archyx/aureliumskills/leveler/SkillLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/leveler/SkillLeveler.java
@@ -48,6 +48,7 @@ public abstract class SkillLeveler {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             double output = getXp(source);
+            Ability ability = this.ability;
             if (ability != null) {
                 if (plugin.getAbilityManager().isEnabled(ability)) {
                     double modifier = 1;
@@ -64,6 +65,7 @@ public abstract class SkillLeveler {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             double output = input;
+            Ability ability = this.ability;
             if (ability != null) {
                 if (plugin.getAbilityManager().isEnabled(ability)) {
                     double modifier = 1;
@@ -80,12 +82,10 @@ public abstract class SkillLeveler {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             double output = input;
-            if (ability != null) {
-                if (plugin.getAbilityManager().isEnabled(ability)) {
-                    double modifier = 1;
-                    modifier += plugin.getAbilityManager().getValue(ability, playerData.getAbilityLevel(ability)) / 100;
-                    output *= modifier;
-                }
+            if (plugin.getAbilityManager().isEnabled(ability)) {
+                double modifier = 1;
+                modifier += plugin.getAbilityManager().getValue(ability, playerData.getAbilityLevel(ability)) / 100;
+                output *= modifier;
             }
             return output;
         }

--- a/src/main/java/com/archyx/aureliumskills/leveler/SkillLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/leveler/SkillLeveler.java
@@ -10,6 +10,7 @@ import com.archyx.aureliumskills.source.Source;
 import com.archyx.aureliumskills.source.SourceManager;
 import com.archyx.aureliumskills.source.SourceTag;
 import com.archyx.aureliumskills.support.WorldGuardFlags;
+import com.archyx.aureliumskills.support.WorldGuardSupport;
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -144,12 +145,14 @@ public abstract class SkillLeveler {
             return player.getGameMode().equals(GameMode.CREATIVE);
         }
         //Checks if in blocked region
-        if (plugin.isWorldGuardEnabled()) {
-            if (plugin.getWorldGuardSupport().isInBlockedRegion(location)) {
+        WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+        if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+            if (worldGuardSupport.isInBlockedRegion(location)) {
                 return true;
             }
             // Check if blocked by flags
-            else return plugin.getWorldGuardSupport().blockedByFlag(location, player, WorldGuardFlags.FlagKey.XP_GAIN);
+            else
+                return worldGuardSupport.blockedByFlag(location, player, WorldGuardFlags.FlagKey.XP_GAIN);
         }
         return false;
     }
@@ -160,12 +163,14 @@ public abstract class SkillLeveler {
             return true;
         }
         //Checks if in blocked region
-        if (plugin.isWorldGuardEnabled()) {
-            if (plugin.getWorldGuardSupport().isInBlockedRegion(location)) {
+        WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+        if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+            if (worldGuardSupport.isInBlockedRegion(location)) {
                 return true;
             }
             // Check if blocked by flags
-            else return plugin.getWorldGuardSupport().blockedByFlag(location, player, WorldGuardFlags.FlagKey.XP_GAIN);
+            else
+                return worldGuardSupport.blockedByFlag(location, player, WorldGuardFlags.FlagKey.XP_GAIN);
         }
         return false;
     }

--- a/src/main/java/com/archyx/aureliumskills/loot/LootTableManager.java
+++ b/src/main/java/com/archyx/aureliumskills/loot/LootTableManager.java
@@ -9,7 +9,6 @@ import com.archyx.lootmanager.loot.LootTable;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -103,7 +102,6 @@ public class LootTableManager extends Parser {
 		plugin.getLogger().info("Loaded " + lootLoaded + " loot entries in " + poolsLoaded + " pools and " + tablesLoaded + " tables");
 	}
 
-	@Nullable
 	public LootTable getLootTable(Skill skill) {
 		return lootTables.get(skill);
 	}

--- a/src/main/java/com/archyx/aureliumskills/loot/SourceContextManager.java
+++ b/src/main/java/com/archyx/aureliumskills/loot/SourceContextManager.java
@@ -6,7 +6,6 @@ import com.archyx.aureliumskills.source.SourceTag;
 import com.archyx.aureliumskills.util.misc.DataUtil;
 import com.archyx.lootmanager.loot.context.ContextManager;
 import com.archyx.lootmanager.loot.context.LootContext;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -20,7 +19,6 @@ public class SourceContextManager extends ContextManager {
     }
 
     @Override
-    @Nullable
     public Set<LootContext> parseContext(Map<?, ?> parentMap) {
         Set<LootContext> contexts = new HashSet<>();
         if (parentMap.containsKey("sources")) {

--- a/src/main/java/com/archyx/aureliumskills/loot/handler/BlockLootHandler.java
+++ b/src/main/java/com/archyx/aureliumskills/loot/handler/BlockLootHandler.java
@@ -71,7 +71,7 @@ public abstract class BlockLootHandler extends LootHandler implements Listener {
             LootDropCause cause = getCause(pool);
 
             // Select pool and give loot
-            if (selectBlockLoot(pool, player, chance, originalSource, event, cause)) {
+            if (originalSource != null && selectBlockLoot(pool, player, chance, originalSource, event, cause)) {
                 break;
             }
         }

--- a/src/main/java/com/archyx/aureliumskills/loot/handler/BlockLootHandler.java
+++ b/src/main/java/com/archyx/aureliumskills/loot/handler/BlockLootHandler.java
@@ -8,6 +8,7 @@ import com.archyx.aureliumskills.data.PlayerData;
 import com.archyx.aureliumskills.skills.Skill;
 import com.archyx.aureliumskills.source.Source;
 import com.archyx.aureliumskills.support.WorldGuardFlags;
+import com.archyx.aureliumskills.support.WorldGuardSupport;
 import com.archyx.lootmanager.loot.Loot;
 import com.archyx.lootmanager.loot.LootPool;
 import com.archyx.lootmanager.loot.LootTable;
@@ -52,8 +53,9 @@ public abstract class BlockLootHandler extends LootHandler implements Listener {
             return;
         }
 
-        if (plugin.isWorldGuardEnabled()) {
-            if (plugin.getWorldGuardSupport().blockedByFlag(block.getLocation(), player, WorldGuardFlags.FlagKey.CUSTOM_LOOT)) {
+        WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+        if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+            if (worldGuardSupport.blockedByFlag(block.getLocation(), player, WorldGuardFlags.FlagKey.CUSTOM_LOOT)) {
                 return;
             }
         }

--- a/src/main/java/com/archyx/aureliumskills/mana/ChargedShot.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ChargedShot.java
@@ -27,7 +27,7 @@ import java.util.Locale;
 public class ChargedShot extends ManaAbilityProvider {
 
     public ChargedShot(AureliumSkills plugin) {
-        super(plugin, MAbility.CHARGED_SHOT, ManaAbilityMessage.CHARGED_SHOT_SHOOT, null);
+        super(plugin, MAbility.CHARGED_SHOT, ManaAbilityMessage.CHARGED_SHOT_SHOOT, ManaAbilityMessage.NONE);
         tickChargedShotCooldown();
     }
 

--- a/src/main/java/com/archyx/aureliumskills/mana/MAbility.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/MAbility.java
@@ -6,7 +6,6 @@ import com.archyx.aureliumskills.lang.Lang;
 import com.archyx.aureliumskills.lang.ManaAbilityMessage;
 import com.archyx.aureliumskills.skills.Skill;
 import com.archyx.aureliumskills.skills.Skills;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -58,9 +57,10 @@ public enum MAbility implements AbstractAbility {
         this.cooldownPerLevel = cooldownPerLevel;
         this.baseManaCost = baseManaCost;
         this.manaCostPerLevel = manaCostPerLevel;
+        this.options = new HashMap<>();
     }
 
-    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String[] optionKeys, Object[] optionValues) {
+    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String [] optionKeys, Object [] optionValues) {
         this(skill, baseValue, valuePerLevel, baseCooldown, cooldownPerLevel, baseManaCost, manaCostPerLevel);
         this.options = new HashMap<>();
         for (int i = 0; i < optionKeys.length; i++) {
@@ -70,7 +70,7 @@ public enum MAbility implements AbstractAbility {
         }
     }
 
-    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String[] optionKeys, Object[] optionValues, Class<? extends ManaAbilityProvider> provider) {
+    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String [] optionKeys, Object [] optionValues, Class<? extends ManaAbilityProvider> provider) {
         this(skill, baseValue, valuePerLevel, baseCooldown, cooldownPerLevel, baseManaCost, manaCostPerLevel, optionKeys, optionValues);
         this.provider = provider;
     }
@@ -139,7 +139,6 @@ public enum MAbility implements AbstractAbility {
         return options;
     }
 
-    @Nullable
     public Class<? extends ManaAbilityProvider> getProvider() {
         return provider;
     }

--- a/src/main/java/com/archyx/aureliumskills/mana/MAbility.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/MAbility.java
@@ -60,7 +60,7 @@ public enum MAbility implements AbstractAbility {
         this.options = new HashMap<>();
     }
 
-    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String [] optionKeys, Object [] optionValues) {
+    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String[] optionKeys, Object[] optionValues) {
         this(skill, baseValue, valuePerLevel, baseCooldown, cooldownPerLevel, baseManaCost, manaCostPerLevel);
         this.options = new HashMap<>();
         for (int i = 0; i < optionKeys.length; i++) {
@@ -70,7 +70,7 @@ public enum MAbility implements AbstractAbility {
         }
     }
 
-    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String [] optionKeys, Object [] optionValues, Class<? extends ManaAbilityProvider> provider) {
+    MAbility(Supplier<Skill> skill, double baseValue, double valuePerLevel, double baseCooldown, double cooldownPerLevel, int baseManaCost, int manaCostPerLevel, String[] optionKeys, Object[] optionValues, Class<? extends ManaAbilityProvider> provider) {
         this(skill, baseValue, valuePerLevel, baseCooldown, cooldownPerLevel, baseManaCost, manaCostPerLevel, optionKeys, optionValues);
         this.provider = provider;
     }

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityManager.java
@@ -14,7 +14,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -65,7 +64,6 @@ public class ManaAbilityManager implements Listener {
         Bukkit.getPluginManager().registerEvents(provider, plugin);
     }
 
-    @Nullable
     public ManaAbilityProvider getProvider(MAbility mAbility) {
         return providers.get(mAbility);
     }
@@ -181,7 +179,9 @@ public class ManaAbilityManager implements Listener {
                     Map<MAbility, Integer> abilityCooldowns = cooldowns.get(id);
                     if (abilityCooldowns != null) {
                         for (MAbility ab : abilityCooldowns.keySet()) {
-                            int cooldown = abilityCooldowns.get(ab);
+                            Integer cooldown = abilityCooldowns.get(ab);
+                            if (cooldown == null)
+                                throw new IllegalStateException("Invalid ability cooldown index key: " + ab);
                             if (cooldown >= 2) {
                                 abilityCooldowns.put(ab, cooldown - 2);
                             } else if (cooldown == 1) {
@@ -208,7 +208,9 @@ public class ManaAbilityManager implements Listener {
                     Map<MAbility, Integer> errorTimers = errorTimer.get(id);
                     if (errorTimers != null) {
                         for (MAbility ab : errorTimers.keySet()) {
-                            int timer = errorTimers.get(ab);
+                            Integer timer = errorTimers.get(ab);
+                            if (timer == null)
+                                throw new IllegalStateException("Invalid ability timer index key: " + timer);
                             if (timer > 0) {
                                 errorTimers.put(ab, timer - 1);
                             }
@@ -385,7 +387,6 @@ public class ManaAbilityManager implements Listener {
      * @param level The skill level
      * @return The mana ability unlocked or leveled up, or null
      */
-    @Nullable
     public MAbility getManaAbility(Skill skill, int level) {
         MAbility mAbility = skill.getManaAbility();
         if (mAbility != null) {
@@ -396,7 +397,6 @@ public class ManaAbilityManager implements Listener {
         return null;
     }
 
-    @Nullable
     public OptionValue getOption(MAbility mAbility, String key) {
         ManaAbilityOption option = plugin.getAbilityManager().getAbilityOption(mAbility);
         if (option != null) {
@@ -435,12 +435,14 @@ public class ManaAbilityManager implements Listener {
         if (value != null) {
             return value.asDouble();
         }
-        return mAbility.getDefaultOptions().get(key).asDouble();
+        value = mAbility.getDefaultOptions().get(key);
+        if (value == null)
+            throw new IllegalStateException("Invalid option index key: " + key);
+        return value.asDouble();
     }
 
-    @Nullable
     public Set<String> getOptionKeys(MAbility mAbility) {
-        if (mAbility.getDefaultOptions() != null) {
+        if (!mAbility.getDefaultOptions().isEmpty()) {
             return mAbility.getDefaultOptions().keySet();
         }
         return null;

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityOption.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityOption.java
@@ -1,7 +1,6 @@
 package com.archyx.aureliumskills.mana;
 
 import com.archyx.aureliumskills.configuration.OptionValue;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -86,7 +85,6 @@ public class ManaAbilityOption {
         return maxLevel;
     }
 
-    @Nullable
     public OptionValue getOption(String key) {
         return options.get(key);
     }

--- a/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityProvider.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ManaAbilityProvider.java
@@ -14,7 +14,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -28,7 +27,7 @@ public abstract class ManaAbilityProvider extends AbilityProvider implements Lis
     protected final ManaAbilityMessage activateMessage;
     protected final ManaAbilityMessage stopMessage;
 
-    public ManaAbilityProvider(AureliumSkills plugin, MAbility mAbility, ManaAbilityMessage activateMessage, @Nullable ManaAbilityMessage stopMessage) {
+    public ManaAbilityProvider(AureliumSkills plugin, MAbility mAbility, ManaAbilityMessage activateMessage, ManaAbilityMessage stopMessage) {
         super(plugin, mAbility.getSkill());
         this.plugin = plugin;
         this.manager = plugin.getManaAbilityManager();
@@ -78,7 +77,7 @@ public abstract class ManaAbilityProvider extends AbilityProvider implements Lis
         onStop(player, playerData); // Mana ability specific stop behavior is run
         manager.setPlayerCooldown(player, mAbility); // Apply cooldown
         // Send stop message if applicable
-        if (stopMessage != null) {
+        if (stopMessage != ManaAbilityMessage.NONE) {
             plugin.getAbilityManager().sendMessage(player, Lang.getMessage(stopMessage, plugin.getLang().getLocale(player)));
         }
     }

--- a/src/main/java/com/archyx/aureliumskills/mana/ReadiedManaAbility.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ReadiedManaAbility.java
@@ -106,7 +106,9 @@ public abstract class ReadiedManaAbility extends ManaAbilityProvider {
             scheduleUnready(player, locale);
         } else { // Cannot ready, send cooldown error
             if (manager.getErrorTimer(player.getUniqueId(), mAbility) == 0) {
-                plugin.getAbilityManager().sendMessage(player, Lang.getMessage(ManaAbilityMessage.NOT_READY, locale).replace("{cooldown}",
+                String m = Lang.getMessage(ManaAbilityMessage.NOT_READY, locale);
+                assert (null != m);
+                plugin.getAbilityManager().sendMessage(player, m.replace("{cooldown}",
                         NumberUtil.format0((double) plugin.getManaAbilityManager().getPlayerCooldown(player.getUniqueId(), mAbility) / 20)));
                 manager.setErrorTimer(player.getUniqueId(), mAbility, 2);
             }
@@ -120,7 +122,9 @@ public abstract class ReadiedManaAbility extends ManaAbilityProvider {
                 if (!manager.isActivated(player.getUniqueId(), mAbility)) {
                     if (manager.isReady(player.getUniqueId(), mAbility)) {
                         manager.setReady(player.getUniqueId(), mAbility, false);
-                        plugin.getAbilityManager().sendMessage(player, Lang.getMessage(ManaAbilityMessage.valueOf(mAbility.name() + "_LOWER"), locale));
+                        String m = Lang.getMessage(ManaAbilityMessage.valueOf(mAbility.name() + "_LOWER"), locale);
+                        assert (null != m);
+                        plugin.getAbilityManager().sendMessage(player, m);
                     }
                 }
             }

--- a/src/main/java/com/archyx/aureliumskills/mana/ReadiedManaAbility.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ReadiedManaAbility.java
@@ -20,12 +20,12 @@ import java.util.Locale;
 
 public abstract class ReadiedManaAbility extends ManaAbilityProvider {
 
-    private final Action [] actions;
-    protected final String [] materials;
+    private final Action[] actions;
+    protected final String[] materials;
 
     private final static int READY_DURATION = 80;
 
-    public ReadiedManaAbility(AureliumSkills plugin, MAbility manaAbility, ManaAbilityMessage activateMessage, ManaAbilityMessage stopMessage, String [] materials, Action [] actions) {
+    public ReadiedManaAbility(AureliumSkills plugin, MAbility manaAbility, ManaAbilityMessage activateMessage, ManaAbilityMessage stopMessage, String[] materials, Action[] actions) {
         super(plugin, manaAbility, activateMessage, stopMessage);
         this.materials = materials;
         this.actions = actions;

--- a/src/main/java/com/archyx/aureliumskills/mana/ReadiedManaAbility.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/ReadiedManaAbility.java
@@ -20,12 +20,12 @@ import java.util.Locale;
 
 public abstract class ReadiedManaAbility extends ManaAbilityProvider {
 
-    private final Action[] actions;
-    protected final String[] materials;
+    private final Action [] actions;
+    protected final String [] materials;
 
     private final static int READY_DURATION = 80;
 
-    public ReadiedManaAbility(AureliumSkills plugin, MAbility manaAbility, ManaAbilityMessage activateMessage, ManaAbilityMessage stopMessage, String[] materials, Action[] actions) {
+    public ReadiedManaAbility(AureliumSkills plugin, MAbility manaAbility, ManaAbilityMessage activateMessage, ManaAbilityMessage stopMessage, String [] materials, Action [] actions) {
         super(plugin, manaAbility, activateMessage, stopMessage);
         this.materials = materials;
         this.actions = actions;
@@ -106,9 +106,7 @@ public abstract class ReadiedManaAbility extends ManaAbilityProvider {
             scheduleUnready(player, locale);
         } else { // Cannot ready, send cooldown error
             if (manager.getErrorTimer(player.getUniqueId(), mAbility) == 0) {
-                String m = Lang.getMessage(ManaAbilityMessage.NOT_READY, locale);
-                assert (null != m);
-                plugin.getAbilityManager().sendMessage(player, m.replace("{cooldown}",
+                plugin.getAbilityManager().sendMessage(player, Lang.getMessage(ManaAbilityMessage.NOT_READY, locale).replace("{cooldown}",
                         NumberUtil.format0((double) plugin.getManaAbilityManager().getPlayerCooldown(player.getUniqueId(), mAbility) / 20)));
                 manager.setErrorTimer(player.getUniqueId(), mAbility, 2);
             }
@@ -122,9 +120,7 @@ public abstract class ReadiedManaAbility extends ManaAbilityProvider {
                 if (!manager.isActivated(player.getUniqueId(), mAbility)) {
                     if (manager.isReady(player.getUniqueId(), mAbility)) {
                         manager.setReady(player.getUniqueId(), mAbility, false);
-                        String m = Lang.getMessage(ManaAbilityMessage.valueOf(mAbility.name() + "_LOWER"), locale);
-                        assert (null != m);
-                        plugin.getAbilityManager().sendMessage(player, m);
+                        plugin.getAbilityManager().sendMessage(player, Lang.getMessage(ManaAbilityMessage.valueOf(mAbility.name() + "_LOWER"), locale));
                     }
                 }
             }

--- a/src/main/java/com/archyx/aureliumskills/mana/SharpHook.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/SharpHook.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 public class SharpHook extends ManaAbilityProvider {
 
     public SharpHook(AureliumSkills plugin) {
-        super(plugin, MAbility.SHARP_HOOK, ManaAbilityMessage.SHARP_HOOK_USE, null);
+        super(plugin, MAbility.SHARP_HOOK, ManaAbilityMessage.SHARP_HOOK_USE, ManaAbilityMessage.NONE);
     }
 
     @Override

--- a/src/main/java/com/archyx/aureliumskills/mana/Terraform.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/Terraform.java
@@ -77,12 +77,13 @@ public class Terraform extends ReadiedManaAbility {
         LinkedList<Block> toCheck = new LinkedList<>();
         toCheck.add(block);
         int count = 0;
-        while ((block = toCheck.poll()) != null && count < 61) {
-            if (block.getType() == material) {
-                block.setMetadata("AureliumSkills-Terraform", new FixedMetadataValue(plugin, true));
-                breakBlock(player, block);
+        Block nextBlock;
+        while ((nextBlock = toCheck.poll()) != null && count < 61) {
+            if (nextBlock.getType() == material) {
+                nextBlock.setMetadata("AureliumSkills-Terraform", new FixedMetadataValue(plugin, true));
+                breakBlock(player, nextBlock);
                 for (BlockFace face : faces) {
-                    toCheck.add(block.getRelative(face));
+                    toCheck.add(nextBlock.getRelative(face));
                 }
                 count++;
             }

--- a/src/main/java/com/archyx/aureliumskills/mana/Terraform.java
+++ b/src/main/java/com/archyx/aureliumskills/mana/Terraform.java
@@ -8,6 +8,8 @@ import com.archyx.aureliumskills.lang.ManaAbilityMessage;
 import com.archyx.aureliumskills.skills.Skills;
 import com.archyx.aureliumskills.skills.excavation.ExcavationSource;
 import com.archyx.aureliumskills.source.SourceTag;
+import com.archyx.aureliumskills.support.TownySupport;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -91,9 +93,12 @@ public class Terraform extends ReadiedManaAbility {
     }
 
     private void breakBlock(Player player, Block block) {
-        if (!plugin.getTownySupport().canBreak(player, block)) {
-            block.removeMetadata("AureliumSkills-Terraform", plugin);
-            return;
+        TownySupport townySupport = plugin.getTownySupport();
+        if (plugin.isTownyEnabled() && townySupport != null) {
+            if (!townySupport.canBreak(player, block)) {
+                block.removeMetadata("AureliumSkills-Terraform", plugin);
+                return;
+            }
         }
         TerraformBlockBreakEvent event = new TerraformBlockBreakEvent(block, player);
         Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/com/archyx/aureliumskills/menus/MenuFileManager.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/MenuFileManager.java
@@ -63,7 +63,7 @@ public class MenuFileManager {
         if (!legacyFile.exists()) return;
 
         FileConfiguration config = YamlConfiguration.loadConfiguration(legacyFile);
-        String[] legacyNames = new String[] {"skills_menu", "stats_menu", "level_progression_menu"};
+        String[] legacyNames = {"skills_menu", "stats_menu", "level_progression_menu"};
         for (String legacyName : legacyNames) {
             ConfigurationSection oldSection = config.getConfigurationSection(legacyName);
             if (oldSection == null) continue;

--- a/src/main/java/com/archyx/aureliumskills/menus/MenuFileManager.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/MenuFileManager.java
@@ -80,13 +80,14 @@ public class MenuFileManager {
             ConfigurationSection fillSection = newConfig.getConfigurationSection("fill");
             if (fillSection != null) {
                 fillSection.set("enabled", oldSection.getBoolean("fill.enabled"));
-                migrateBaseItem(fillSection, oldSection.getString("fill.material", "black_stained_glass_pane"));
+                String material = oldSection.getString("fill.material");
+                migrateBaseItem(fillSection, material != null ? material : "black_stained_glass_pane");
             }
             // Migrate items
             ConfigurationSection itemsSection = oldSection.getConfigurationSection("items");
             ConfigurationSection newItemsSection = newConfig.getConfigurationSection("items");
             ConfigurationSection newTemplatesSection = newConfig.getConfigurationSection("templates");
-            if (itemsSection != null && newItemsSection != null) {
+            if (itemsSection != null && newItemsSection != null && newTemplatesSection != null) {
                 migrateItems(itemsSection, newItemsSection, newTemplatesSection);
             }
             // Migrate templates
@@ -140,7 +141,7 @@ public class MenuFileManager {
                 }
                 // Migrate material item contexts
                 for (String material : materialList) {
-                    String[] splitMaterial = material.split(" ", 2);
+                    String [] splitMaterial = material.split(" ", 2);
                     if (splitMaterial.length < 2) continue;
                     String contextString = splitMaterial[0].toLowerCase(Locale.ROOT);
 

--- a/src/main/java/com/archyx/aureliumskills/menus/MenuFileManager.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/MenuFileManager.java
@@ -141,7 +141,7 @@ public class MenuFileManager {
                 }
                 // Migrate material item contexts
                 for (String material : materialList) {
-                    String [] splitMaterial = material.split(" ", 2);
+                    String[] splitMaterial = material.split(" ", 2);
                     if (splitMaterial.length < 2) continue;
                     String contextString = splitMaterial[0].toLowerCase(Locale.ROOT);
 

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/AbilitiesMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/AbilitiesMenu.java
@@ -19,16 +19,22 @@ public class AbilitiesMenu extends AbstractMenu implements MenuProvider {
     }
 
     @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu) {
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu) {
         Locale locale = plugin.getLang().getLocale(player);
         if ("abilities_title".equals(placeholder)) {
-            Object property = menu.getProperty("skill");
-            assert (null != property);
-            Skill skill = (Skill) property;
+            Skill skill = getSkill(activeMenu);
             return TextUtil.replace(Lang.getMessage(MenuMessage.ABILITIES_TITLE, locale),
                     "{skill}", skill.getDisplayName(locale));
         }
         return placeholder;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/AbilitiesMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/AbilitiesMenu.java
@@ -22,7 +22,9 @@ public class AbilitiesMenu extends AbstractMenu implements MenuProvider {
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu) {
         Locale locale = plugin.getLang().getLocale(player);
         if ("abilities_title".equals(placeholder)) {
-            Skill skill = (Skill) menu.getProperty("skill");
+            Object property = menu.getProperty("skill");
+            assert (null != property);
+            Skill skill = (Skill) property;
             return TextUtil.replace(Lang.getMessage(MenuMessage.ABILITIES_TITLE, locale),
                     "{skill}", skill.getDisplayName(locale));
         }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/AbstractAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/AbstractAbilityItem.java
@@ -33,9 +33,7 @@ public abstract class AbstractAbilityItem extends AbstractItem implements Templa
 
     @Override
     public SlotPos getSlotPos(Player player, ActiveMenu activeMenu, Ability ability) {
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         Object obj =  activeMenu.getItemOption(itemName, "slots");
         if (obj instanceof List<?>) {
             List<String> slots = DataUtil.castStringList(obj);
@@ -87,4 +85,13 @@ public abstract class AbstractAbilityItem extends AbstractItem implements Templa
         }
         return baseItem;
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/AbstractAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/AbstractAbilityItem.java
@@ -33,7 +33,9 @@ public abstract class AbstractAbilityItem extends AbstractItem implements Templa
 
     @Override
     public SlotPos getSlotPos(Player player, ActiveMenu activeMenu, Ability ability) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         Object obj =  activeMenu.getItemOption(itemName, "slots");
         if (obj instanceof List<?>) {
             List<String> slots = DataUtil.castStringList(obj);

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedAbilityItem.java
@@ -25,7 +25,7 @@ public class LockedAbilityItem extends AbstractAbilityItem {
     }
 
     @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu, PlaceholderType type, Ability ability) {
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, Ability ability) {
         Locale locale = plugin.getLang().getLocale(player);
         switch (placeholder) {
             case "name":
@@ -33,12 +33,10 @@ public class LockedAbilityItem extends AbstractAbilityItem {
             case "locked_desc":
                 return TextUtil.replace(Lang.getMessage(MenuMessage.LOCKED_DESC, locale),
                         "{desc}", TextUtil.replace(ability.getDescription(locale),
-                                "{value}", NumberUtil.format1(plugin.getAbilityManager().getValue(ability, 1)),
-                                "{value_2}", NumberUtil.format1(plugin.getAbilityManager().getValue2(ability, 1))));
+                        "{value}", NumberUtil.format1(plugin.getAbilityManager().getValue(ability, 1)),
+                        "{value_2}", NumberUtil.format1(plugin.getAbilityManager().getValue2(ability, 1))));
             case "unlocked_at":
-                Object property = menu.getProperty("skill");
-                assert (null != property);
-                Skill skill = (Skill) property;
+                Skill skill = getSkill(activeMenu);
                 return TextUtil.replace(Lang.getMessage(MenuMessage.UNLOCKED_AT, locale),
                         "{skill}", skill.getDisplayName(locale),
                         "{level}", RomanNumber.toRoman(plugin.getAbilityManager().getUnlock(ability)));
@@ -50,12 +48,10 @@ public class LockedAbilityItem extends AbstractAbilityItem {
 
     @Override
     public Set<Ability> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
-        PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         Set<Ability> lockedAbilities = new HashSet<>();
+        PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
+            Skill skill = getSkill(activeMenu);
             // Add abilities that player has not unlocked yet
             for (Supplier<Ability> abilitySupplier : skill.getAbilities()) {
                 Ability ability = abilitySupplier.get();
@@ -66,4 +62,13 @@ public class LockedAbilityItem extends AbstractAbilityItem {
         }
         return lockedAbilities;
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedAbilityItem.java
@@ -36,7 +36,9 @@ public class LockedAbilityItem extends AbstractAbilityItem {
                                 "{value}", NumberUtil.format1(plugin.getAbilityManager().getValue(ability, 1)),
                                 "{value_2}", NumberUtil.format1(plugin.getAbilityManager().getValue2(ability, 1))));
             case "unlocked_at":
-                Skill skill = (Skill) menu.getProperty("skill");
+                Object property = menu.getProperty("skill");
+                assert (null != property);
+                Skill skill = (Skill) property;
                 return TextUtil.replace(Lang.getMessage(MenuMessage.UNLOCKED_AT, locale),
                         "{skill}", skill.getDisplayName(locale),
                         "{level}", RomanNumber.toRoman(plugin.getAbilityManager().getUnlock(ability)));
@@ -48,7 +50,9 @@ public class LockedAbilityItem extends AbstractAbilityItem {
 
     @Override
     public Set<Ability> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         Set<Ability> lockedAbilities = new HashSet<>();
         if (playerData != null) {

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedManaAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedManaAbilityItem.java
@@ -31,7 +31,9 @@ public class LockedManaAbilityItem extends AbstractManaAbilityItem implements Te
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu, PlaceholderType type, MAbility mAbility) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) menu.getProperty("skill");
+        Object property = menu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         switch (placeholder) {
             case "name":
                 return mAbility.getDisplayName(locale);
@@ -54,7 +56,9 @@ public class LockedManaAbilityItem extends AbstractManaAbilityItem implements Te
     @Override
     public Set<MAbility> getDefinedContexts(Player player, ActiveMenu activeMenu) {
         Set<MAbility> lockedManaAbilities = new HashSet<>();
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         MAbility mAbility = skill.getManaAbility();
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (mAbility != null && playerData != null) {

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedManaAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/LockedManaAbilityItem.java
@@ -29,11 +29,9 @@ public class LockedManaAbilityItem extends AbstractManaAbilityItem implements Te
     }
 
     @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu, PlaceholderType type, MAbility mAbility) {
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, MAbility mAbility) {
         Locale locale = plugin.getLang().getLocale(player);
-        Object property = menu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         switch (placeholder) {
             case "name":
                 return mAbility.getDisplayName(locale);
@@ -56,9 +54,7 @@ public class LockedManaAbilityItem extends AbstractManaAbilityItem implements Te
     @Override
     public Set<MAbility> getDefinedContexts(Player player, ActiveMenu activeMenu) {
         Set<MAbility> lockedManaAbilities = new HashSet<>();
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         MAbility mAbility = skill.getManaAbility();
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (mAbility != null && playerData != null) {
@@ -75,6 +71,14 @@ public class LockedManaAbilityItem extends AbstractManaAbilityItem implements Te
         } else {
             return manager.getValue(mAbility, 1);
         }
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedAbilityItem.java
@@ -26,9 +26,10 @@ public class UnlockedAbilityItem extends AbstractAbilityItem {
     }
 
     @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu, PlaceholderType type, Ability ability) {
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, Ability ability) {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        if (playerData == null) return placeholder;
+        if (playerData == null)
+            return placeholder;
         Locale locale = plugin.getLang().getLocale(player);
         switch (placeholder) {
             case "name":
@@ -56,9 +57,7 @@ public class UnlockedAbilityItem extends AbstractAbilityItem {
                                     "{value_2}", getCurrentValue2(ability, playerData)));
                 }
             case "unlocked":
-                String t = Lang.getMessage(MenuMessage.UNLOCKED, locale);
-                assert (null != t);
-                return t;
+                return Lang.getMessage(MenuMessage.UNLOCKED, locale);
         }
         return placeholder;
     }
@@ -102,20 +101,27 @@ public class UnlockedAbilityItem extends AbstractAbilityItem {
 
     @Override
     public Set<Ability> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
-        PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         Set<Ability> unlockedAbilities = new HashSet<>();
-        if (playerData != null) {
-            // Add abilities that player has not unlocked yet
-            for (Supplier<Ability> abilitySupplier : skill.getAbilities()) {
-                Ability ability = abilitySupplier.get();
-                if (playerData.getAbilityLevel(ability) >= 1) {
-                    unlockedAbilities.add(ability);
-                }
+        PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
+        if (playerData == null)
+            return unlockedAbilities;
+        Skill skill = getSkill(activeMenu);
+        // Add abilities that player has not unlocked yet
+        for (Supplier<Ability> abilitySupplier : skill.getAbilities()) {
+            Ability ability = abilitySupplier.get();
+            if (playerData.getAbilityLevel(ability) >= 1) {
+                unlockedAbilities.add(ability);
             }
         }
         return unlockedAbilities;
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedAbilityItem.java
@@ -56,7 +56,9 @@ public class UnlockedAbilityItem extends AbstractAbilityItem {
                                     "{value_2}", getCurrentValue2(ability, playerData)));
                 }
             case "unlocked":
-                return Lang.getMessage(MenuMessage.UNLOCKED, locale);
+                String t = Lang.getMessage(MenuMessage.UNLOCKED, locale);
+                assert (null != t);
+                return t;
         }
         return placeholder;
     }
@@ -100,7 +102,9 @@ public class UnlockedAbilityItem extends AbstractAbilityItem {
 
     @Override
     public Set<Ability> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         Set<Ability> unlockedAbilities = new HashSet<>();
         if (playerData != null) {

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedManaAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedManaAbilityItem.java
@@ -30,10 +30,11 @@ public class UnlockedManaAbilityItem extends AbstractManaAbilityItem implements 
     }
 
     @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu, PlaceholderType type, MAbility mAbility) {
-        Locale locale = plugin.getLang().getLocale(player);
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, MAbility mAbility) {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        if (playerData == null) return placeholder;
+        if (playerData == null)
+            return placeholder;
+        Locale locale = plugin.getLang().getLocale(player);
         switch (placeholder) {
             case "name":
                 return mAbility.getDisplayName(locale);
@@ -98,9 +99,7 @@ public class UnlockedManaAbilityItem extends AbstractManaAbilityItem implements 
 
     @Override
     public Set<MAbility> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         Set<MAbility> unlockedManaAbilities = new HashSet<>();
         if (playerData != null) {
@@ -121,6 +120,14 @@ public class UnlockedManaAbilityItem extends AbstractManaAbilityItem implements 
         } else {
             return manager.getValue(mAbility, level);
         }
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedManaAbilityItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/abilities/UnlockedManaAbilityItem.java
@@ -98,7 +98,9 @@ public class UnlockedManaAbilityItem extends AbstractManaAbilityItem implements 
 
     @Override
     public Set<MAbility> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         Set<MAbility> unlockedManaAbilities = new HashSet<>();
         if (playerData != null) {

--- a/src/main/java/com/archyx/aureliumskills/menus/common/AbstractSkillItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/common/AbstractSkillItem.java
@@ -42,7 +42,8 @@ public abstract class AbstractSkillItem extends AbstractItem implements Template
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, Skill skill) {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        if (playerData == null) return placeholder;
+        if (playerData == null)
+            return placeholder;
         Locale locale = playerData.getLocale();
         int skillLevel = playerData.getSkillLevel(skill);
 
@@ -122,8 +123,8 @@ public abstract class AbstractSkillItem extends AbstractItem implements Template
                                 , "{ability}", ability.getDisplayName(locale)
                                 , "{level}", RomanNumber.toRoman(playerData.getAbilityLevel(ability))
                                 , "{info}", TextUtil.replace(ability.getInfo(locale)
-                                        , "{value}", NumberUtil.format1(plugin.getAbilityManager().getValue(ability, abilityLevel))
-                                        , "{value_2}", NumberUtil.format1(plugin.getAbilityManager().getValue2(ability, abilityLevel)))));
+                                , "{value}", NumberUtil.format1(plugin.getAbilityManager().getValue(ability, abilityLevel))
+                                , "{value_2}", NumberUtil.format1(plugin.getAbilityManager().getValue2(ability, abilityLevel)))));
                     } else {
                         levelsMessage = TextUtil.replace(levelsMessage, "{ability_" + num + "}", TextUtil.replace(Lang.getMessage(MenuMessage.ABILITY_LEVEL_ENTRY_LOCKED, locale)
                                 , "{ability}", ability.getDisplayName(locale)));

--- a/src/main/java/com/archyx/aureliumskills/menus/common/BackItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/common/BackItem.java
@@ -27,7 +27,7 @@ public class BackItem extends AbstractItem implements SingleItemProvider {
             case "back":
                 return Lang.getMessage(MenuMessage.BACK, locale);
             case "back_click":
-                String previousMenu = (String) activeMenu.getProperty("previous_menu");
+                String previousMenu = getPreviousMenu(activeMenu);
                 String formattedPreviousMenu = TextUtil.capitalizeWord(TextUtil.replace(previousMenu, "_", " "));
                 return TextUtil.replace(Lang.getMessage(MenuMessage.BACK_CLICK, locale),
                         "{menu_name}", formattedPreviousMenu);
@@ -37,18 +37,25 @@ public class BackItem extends AbstractItem implements SingleItemProvider {
 
     @Override
     public void onClick(Player player, InventoryClickEvent event, ItemStack item, SlotPos pos, ActiveMenu activeMenu) {
-        Object object = activeMenu.getProperty("previous_menu");
-        if (object != null) {
-            String previousMenu = (String) object;
+        String previousMenu = getPreviousMenu(activeMenu);
+        if (!previousMenu.isEmpty())
             plugin.getMenuManager().openMenu(player, previousMenu);
-        }
     }
 
     @Override
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu) {
-        if (activeMenu.getProperty("previous_menu") == null) {
+        if (getPreviousMenu(activeMenu).isEmpty()) {
             return null;
         }
         return baseItem;
     }
+
+    private String getPreviousMenu(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("previous_menu");
+        if (!(property instanceof String)) {
+            property = "";
+        }
+        return (String) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/common/BackToLevelProgressionItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/common/BackToLevelProgressionItem.java
@@ -18,11 +18,19 @@ public class BackToLevelProgressionItem extends BackItem {
 
     @Override
     public void onClick(Player player, InventoryClickEvent event, ItemStack item, SlotPos pos, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Skill skill = getSkill(activeMenu);
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             new LevelProgressionOpener(plugin).open(player, playerData, skill);
         }
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/AbilityContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/AbilityContext.java
@@ -2,14 +2,12 @@ package com.archyx.aureliumskills.menus.contexts;
 
 import com.archyx.aureliumskills.ability.Ability;
 import com.archyx.slate.context.ContextProvider;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
 public class AbilityContext implements ContextProvider<Ability> {
 
     @Override
-    @Nullable
     public Ability parse(String input) {
         try {
             return Ability.valueOf(input.toUpperCase(Locale.ROOT));

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/ManaAbilityContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/ManaAbilityContext.java
@@ -2,14 +2,12 @@ package com.archyx.aureliumskills.menus.contexts;
 
 import com.archyx.aureliumskills.mana.MAbility;
 import com.archyx.slate.context.ContextProvider;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
 public class ManaAbilityContext implements ContextProvider<MAbility> {
 
     @Override
-    @Nullable
     public MAbility parse(String input) {
         return MAbility.valueOf(input.toUpperCase(Locale.ROOT));
     }

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/SkillContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/SkillContext.java
@@ -16,6 +16,7 @@ public class SkillContext implements ContextProvider<Skill> {
     @Nullable
     @Override
     public Skill parse(String input) {
+        assert (null != input);
         return plugin.getSkillRegistry().getSkill(input);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/SkillContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/SkillContext.java
@@ -3,7 +3,6 @@ package com.archyx.aureliumskills.menus.contexts;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.skills.Skill;
 import com.archyx.slate.context.ContextProvider;
-import org.jetbrains.annotations.Nullable;
 
 public class SkillContext implements ContextProvider<Skill> {
 
@@ -13,10 +12,8 @@ public class SkillContext implements ContextProvider<Skill> {
         this.plugin = plugin;
     }
 
-    @Nullable
     @Override
     public Skill parse(String input) {
-        assert (null != input);
         return plugin.getSkillRegistry().getSkill(input);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/SortTypeContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/SortTypeContext.java
@@ -2,13 +2,11 @@ package com.archyx.aureliumskills.menus.contexts;
 
 import com.archyx.aureliumskills.menus.sources.SorterItem;
 import com.archyx.slate.context.ContextProvider;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
 public class SortTypeContext implements ContextProvider<SorterItem.SortType> {
 
-    @Nullable
     @Override
     public SorterItem.SortType parse(String s) {
         return SorterItem.SortType.valueOf(s.toUpperCase(Locale.ROOT));

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/SourceContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/SourceContext.java
@@ -3,7 +3,6 @@ package com.archyx.aureliumskills.menus.contexts;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.source.Source;
 import com.archyx.slate.context.ContextProvider;
-import org.jetbrains.annotations.Nullable;
 
 public class SourceContext implements ContextProvider<Source> {
 
@@ -14,7 +13,6 @@ public class SourceContext implements ContextProvider<Source> {
     }
 
     @Override
-    @Nullable
     public Source parse(String input) {
         return plugin.getSourceRegistry().valueOf(input);
     }

--- a/src/main/java/com/archyx/aureliumskills/menus/contexts/StatContext.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/contexts/StatContext.java
@@ -3,7 +3,6 @@ package com.archyx.aureliumskills.menus.contexts;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.stats.Stat;
 import com.archyx.slate.context.ContextProvider;
-import org.jetbrains.annotations.Nullable;
 
 public class StatContext implements ContextProvider<Stat> {
 
@@ -13,7 +12,6 @@ public class StatContext implements ContextProvider<Stat> {
         this.plugin = plugin;
     }
 
-    @Nullable
     @Override
     public Stat parse(String input) {
         return plugin.getStatRegistry().getStat(input);

--- a/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardMenu.java
@@ -21,14 +21,20 @@ public class LeaderboardMenu extends AbstractMenu implements MenuProvider {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu) {
         Locale locale = plugin.getLang().getLocale(player);
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         if (placeholder.equals("leaderboard_menu_title")) {
             return TextUtil.replace(Lang.getMessage(MenuMessage.LEADERBOARD_TITLE, locale),
                     "{skill}", skill.getDisplayName(locale));
         }
         return placeholder;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardMenu.java
@@ -21,7 +21,9 @@ public class LeaderboardMenu extends AbstractMenu implements MenuProvider {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         if (placeholder.equals("leaderboard_menu_title")) {
             return TextUtil.replace(Lang.getMessage(MenuMessage.LEADERBOARD_TITLE, locale),
                     "{skill}", skill.getDisplayName(locale));

--- a/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardPlayerItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardPlayerItem.java
@@ -33,7 +33,7 @@ public class LeaderboardPlayerItem extends AbstractItem implements TemplateItemP
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer place) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Skill skill = getSkill(activeMenu);
         SkillValue value = plugin.getLeaderboardManager().getLeaderboard(skill, place, 1).get(0);
         switch (placeholder) {
             case "player_entry":
@@ -60,7 +60,7 @@ public class LeaderboardPlayerItem extends AbstractItem implements TemplateItemP
 
     @Override
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu, Integer place) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Skill skill = getSkill(activeMenu);
         List<SkillValue> values = plugin.getLeaderboardManager().getLeaderboard(skill, place, 1);
         if (values.size() == 0) {
             return null;
@@ -85,4 +85,13 @@ public class LeaderboardPlayerItem extends AbstractItem implements TemplateItemP
         }
         return baseItem;
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardPlayerItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/leaderboard/LeaderboardPlayerItem.java
@@ -77,7 +77,10 @@ public class LeaderboardPlayerItem extends AbstractItem implements TemplateItemP
             }
             // Set the player skin on the head
             SkullMeta meta = (SkullMeta) baseItem.getItemMeta();
-            meta.setOwningPlayer(Bukkit.getOfflinePlayer(id));
+            
+            if (meta != null)
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer(id));
+            
             baseItem.setItemMeta(meta);
         }
         return baseItem;

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/AbilitiesItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/AbilitiesItem.java
@@ -36,7 +36,9 @@ public class AbilitiesItem extends AbstractItem implements SingleItemProvider {
             case "abilities_desc":
                 return Lang.getMessage(MenuMessage.ABILITIES_DESC, locale);
             case "abilities_click":
-                Skill skill = (Skill) menu.getProperty("skill");
+                Object property = menu.getProperty("skill");
+                assert (null != property);
+                Skill skill = (Skill) property;
                 return TextUtil.replace(Lang.getMessage(MenuMessage.ABILITIES_CLICK, locale), "{skill}", skill.getDisplayName(locale));
         }
         return placeholder;
@@ -52,7 +54,9 @@ public class AbilitiesItem extends AbstractItem implements SingleItemProvider {
 
     @Override
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         if (skill == Skills.SORCERY) { // Disable for sorcery abilities REMOVE ONCE SORCERY ABILITIES ARE ADDED
             return null;
         }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/AbilitiesItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/AbilitiesItem.java
@@ -28,7 +28,7 @@ public class AbilitiesItem extends AbstractItem implements SingleItemProvider {
     }
 
     @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu, PlaceholderType type) {
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type) {
         Locale locale = plugin.getLang().getLocale(player);
         switch (placeholder) {
             case "abilities":
@@ -36,9 +36,7 @@ public class AbilitiesItem extends AbstractItem implements SingleItemProvider {
             case "abilities_desc":
                 return Lang.getMessage(MenuMessage.ABILITIES_DESC, locale);
             case "abilities_click":
-                Object property = menu.getProperty("skill");
-                assert (null != property);
-                Skill skill = (Skill) property;
+                Skill skill = getSkill(activeMenu);
                 return TextUtil.replace(Lang.getMessage(MenuMessage.ABILITIES_CLICK, locale), "{skill}", skill.getDisplayName(locale));
         }
         return placeholder;
@@ -47,16 +45,14 @@ public class AbilitiesItem extends AbstractItem implements SingleItemProvider {
     @Override
     public void onClick(Player player, InventoryClickEvent event, ItemStack item, SlotPos pos, ActiveMenu activeMenu) {
         Map<String, Object> properties = new HashMap<>();
-        properties.put("skill", activeMenu.getProperty("skill"));
+        properties.put("skill", getSkill(activeMenu));
         properties.put("previous_menu", "level_progression");
         plugin.getMenuManager().openMenu(player, "abilities", properties);
     }
 
     @Override
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu) {
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         if (skill == Skills.SORCERY) { // Disable for sorcery abilities REMOVE ONCE SORCERY ABILITIES ARE ADDED
             return null;
         }
@@ -70,8 +66,16 @@ public class AbilitiesItem extends AbstractItem implements SingleItemProvider {
         }
         if (hasEnabledAbility) {
             return baseItem;
-        } else {
-            return null; // Don't show item if no abilities are enabled
         }
+        return null; // Don't show item if no abilities are enabled
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/InProgressItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/InProgressItem.java
@@ -25,7 +25,9 @@ public class InProgressItem extends SkillLevelItem {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer position) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData == null) return placeholder;
         int level = getLevel(activeMenu, position);
@@ -56,7 +58,9 @@ public class InProgressItem extends SkillLevelItem {
     @Override
     public Set<Integer> getDefinedContexts(Player player, ActiveMenu activeMenu) {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         int itemsPerPage = getItemsPerPage(activeMenu);
         int currentPage = activeMenu.getCurrentPage();
         if (playerData != null) {

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/InProgressItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/InProgressItem.java
@@ -25,11 +25,10 @@ public class InProgressItem extends SkillLevelItem {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer position) {
         Locale locale = plugin.getLang().getLocale(player);
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        if (playerData == null) return placeholder;
+        if (playerData == null)
+            return placeholder;
         int level = getLevel(activeMenu, position);
         switch (placeholder) {
             case "level_in_progress":
@@ -57,27 +56,32 @@ public class InProgressItem extends SkillLevelItem {
 
     @Override
     public Set<Integer> getDefinedContexts(Player player, ActiveMenu activeMenu) {
+        Set<Integer> levels = new HashSet<>();
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        if (playerData == null)
+            return levels;
+        Skill skill = getSkill(activeMenu);
         int itemsPerPage = getItemsPerPage(activeMenu);
         int currentPage = activeMenu.getCurrentPage();
-        if (playerData != null) {
-            int level = playerData.getSkillLevel(skill);
-            if (level >= 1 + currentPage * itemsPerPage && level < (currentPage + 1) * itemsPerPage + 2) {
-                Set<Integer> levels = new HashSet<>();
-                int position = (level + 1) % itemsPerPage; // Calculate the first-page equivalent next level
-                if (position == 0) { // Account for next skill level 24
-                    position = 24;
-                } else if (position == 1) { // Account for next skill level 25
-                    position = 25;
-                }
-                levels.add(position);
-                return levels;
+        int level = playerData.getSkillLevel(skill);
+        if (level >= 1 + currentPage * itemsPerPage && level < (currentPage + 1) * itemsPerPage + 2) {
+            int position = (level + 1) % itemsPerPage; // Calculate the first-page equivalent next level
+            if (position == 0) { // Account for next skill level 24
+                position = 24;
+            } else if (position == 1) { // Account for next skill level 25
+                position = 25;
             }
+            levels.add(position);
         }
-        return new HashSet<>();
+        return levels;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/LevelProgressionMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/LevelProgressionMenu.java
@@ -34,7 +34,7 @@ public class LevelProgressionMenu extends AbstractMenu implements MenuProvider {
 
     @Override
     public int getPages(Player player, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Skill skill = getSkill(activeMenu);
         int itemsPerPage = 24;
         ConfigurableMenu levelProgressionMenu = plugin.getSlate().getMenuManager().getMenu("level_progression");
         if (levelProgressionMenu != null) {
@@ -48,10 +48,10 @@ public class LevelProgressionMenu extends AbstractMenu implements MenuProvider {
 
     private Skill getSkill(ActiveMenu activeMenu) {
         Object property = activeMenu.getProperty("skill");
-        if (property instanceof Skill) {
-            return (Skill) property;
-        } else {
-            throw new IllegalArgumentException("Could not get skill property");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
         }
+        return (Skill) property;
     }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/LockedItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/LockedItem.java
@@ -24,7 +24,9 @@ public class LockedItem extends SkillLevelItem {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer position) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         int level = getLevel(activeMenu, position);
         switch (placeholder) {
             case "level_locked":

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/LockedItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/LockedItem.java
@@ -24,9 +24,7 @@ public class LockedItem extends SkillLevelItem {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer position) {
         Locale locale = plugin.getLang().getLocale(player);
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         int level = getLevel(activeMenu, position);
         switch (placeholder) {
             case "level_locked":
@@ -47,23 +45,30 @@ public class LockedItem extends SkillLevelItem {
 
     @Override
     public Set<Integer> getDefinedContexts(Player player, ActiveMenu activeMenu) {
+        Set<Integer> levels = new HashSet<>();
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        if (playerData != null) {
-            Skill skill = (Skill) activeMenu.getProperty("skill");
-            int level = playerData.getSkillLevel(skill);
-            int itemsPerPage = getItemsPerPage(activeMenu);
-            int currentPage = activeMenu.getCurrentPage();
-            Set<Integer> levels = new HashSet<>();
-            for (int i = itemsPerPage - 1; i >= 0; i--) {
-                if (1 + currentPage * itemsPerPage + i > level) {
-                    levels.add(2 + i);
-                } else {
-                    break;
-                }
-            }
+        if (playerData == null)
             return levels;
+        Skill skill = getSkill(activeMenu);
+        int level = playerData.getSkillLevel(skill);
+        int itemsPerPage = getItemsPerPage(activeMenu);
+        int currentPage = activeMenu.getCurrentPage();
+        for (int i = itemsPerPage - 1; i >= 0; i--) {
+            if (1 + currentPage * itemsPerPage + i > level) {
+                levels.add(2 + i);
+            } else {
+                break;
+            }
         }
-        return new HashSet<>();
+        return levels;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/RankItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/RankItem.java
@@ -27,7 +27,9 @@ public class RankItem extends AbstractItem implements SingleItemProvider {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         switch (placeholder) {
             case "your_ranking":
                 return Lang.getMessage(MenuMessage.YOUR_RANKING, locale);

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/RankItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/RankItem.java
@@ -27,9 +27,7 @@ public class RankItem extends AbstractItem implements SingleItemProvider {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type) {
         Locale locale = plugin.getLang().getLocale(player);
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         switch (placeholder) {
             case "your_ranking":
                 return Lang.getMessage(MenuMessage.YOUR_RANKING, locale);
@@ -75,4 +73,13 @@ public class RankItem extends AbstractItem implements SingleItemProvider {
     private int getSize(Skill skill, Player player) {
         return plugin.getLeaderboardManager().getLeaderboard(skill).size();
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SkillLevelItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SkillLevelItem.java
@@ -57,7 +57,9 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu, Integer num) {
         // Functionality for showing the level as the amount on the item
         int page = activeMenu.getCurrentPage();
-        int level = num + page * (int) activeMenu.getProperty("items_per_page");
+        Object property = activeMenu.getProperty("items_per_page");
+        assert (null != property);
+        int level = num + page * (int)property;
         // Don't show if level is more than max skill level
         Skill skill = (Skill) activeMenu.getProperty("skill");
         if (level > OptionL.getMaxLevel(skill)) {

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SkillLevelItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SkillLevelItem.java
@@ -57,11 +57,9 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu, Integer num) {
         // Functionality for showing the level as the amount on the item
         int page = activeMenu.getCurrentPage();
-        Object property = activeMenu.getProperty("items_per_page");
-        assert (null != property);
-        int level = num + page * (int)property;
+        int level = num + page * getItemsPerPage(activeMenu);
         // Don't show if level is more than max skill level
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Skill skill = getSkill(activeMenu);
         if (level > OptionL.getMaxLevel(skill)) {
             return null;
         }
@@ -111,8 +109,8 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
                         abilityLore.append(TextUtil.replace(Lang.getMessage(MenuMessage.ABILITY_UNLOCK, locale)
                                 , "{ability}", ability.getDisplayName(locale)
                                 , "{desc}", TextUtil.replace(ability.getDescription(locale)
-                                        , "{value_2}", NumberUtil.format1(manager.getValue2(ability, 1))
-                                        , "{value}", NumberUtil.format1(manager.getValue(ability, 1)))));
+                                , "{value_2}", NumberUtil.format1(manager.getValue2(ability, 1))
+                                , "{value}", NumberUtil.format1(manager.getValue(ability, 1)))));
                     } else {
                         int abilityLevel = ((level - manager.getUnlock(ability)) / manager.getLevelUp(ability)) + 1;
                         if (abilityLevel <= manager.getMaxLevel(ability) || manager.getMaxLevel(ability) == 0) { // Check max level
@@ -120,8 +118,8 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
                                     , "{ability}", ability.getDisplayName(locale)
                                     , "{level}", RomanNumber.toRoman(abilityLevel)
                                     , "{desc}", TextUtil.replace(ability.getDescription(locale)
-                                            , "{value_2}", NumberUtil.format1(manager.getValue2(ability, abilityLevel))
-                                            , "{value}", NumberUtil.format1(manager.getValue(ability, abilityLevel)))));
+                                    , "{value_2}", NumberUtil.format1(manager.getValue2(ability, abilityLevel))
+                                    , "{value}", NumberUtil.format1(manager.getValue(ability, abilityLevel)))));
                         }
                     }
                 }
@@ -140,9 +138,9 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
                     manaAbilityLore.append(TextUtil.replace(Lang.getMessage(MenuMessage.MANA_ABILITY_UNLOCK, locale)
                             , "{mana_ability}", mAbility.getDisplayName(locale)
                             , "{desc}", TextUtil.replace(mAbility.getDescription(locale)
-                                    , "{value}", NumberUtil.format1(manager.getDisplayValue(mAbility, 1))
-                                    , "{duration}", NumberUtil.format1(getDuration(mAbility, 1))
-                                    , "{haste_level}", String.valueOf(manager.getOptionAsInt(MAbility.SPEED_MINE, "haste_level", 10)))));
+                            , "{value}", NumberUtil.format1(manager.getDisplayValue(mAbility, 1))
+                            , "{duration}", NumberUtil.format1(getDuration(mAbility, 1))
+                            , "{haste_level}", String.valueOf(manager.getOptionAsInt(MAbility.SPEED_MINE, "haste_level", 10)))));
                 }
                 else {
                     int manaAbilityLevel = ((level - manager.getUnlock(mAbility)) / manager.getLevelUp(mAbility)) + 1;
@@ -151,9 +149,9 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
                                 , "{mana_ability}", mAbility.getDisplayName(locale)
                                 , "{level}", RomanNumber.toRoman(manaAbilityLevel)
                                 , "{desc}", TextUtil.replace(mAbility.getDescription(locale)
-                                        , "{value}", NumberUtil.format1(manager.getDisplayValue(mAbility, manaAbilityLevel))
-                                        , "{duration}", NumberUtil.format1(getDuration(mAbility, manaAbilityLevel))
-                                        , "{haste_level}", String.valueOf(manager.getOptionAsInt(MAbility.SPEED_MINE, "haste_level", 10)))));
+                                , "{value}", NumberUtil.format1(manager.getDisplayValue(mAbility, manaAbilityLevel))
+                                , "{duration}", NumberUtil.format1(getDuration(mAbility, manaAbilityLevel))
+                                , "{haste_level}", String.valueOf(manager.getOptionAsInt(MAbility.SPEED_MINE, "haste_level", 10)))));
                     }
                 }
             }
@@ -186,6 +184,14 @@ public abstract class SkillLevelItem extends AbstractItem implements TemplateIte
         int itemsPerPage = getItemsPerPage(activeMenu);
         int currentPage = activeMenu.getCurrentPage();
         return currentPage * itemsPerPage + position;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SourcesItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SourcesItem.java
@@ -34,7 +34,9 @@ public class SourcesItem extends AbstractItem implements SingleItemProvider {
             case "sources_desc":
                 return Lang.getMessage(MenuMessage.SOURCES_DESC, locale);
             case "sources_click":
-                Skill skill = (Skill) activeMenu.getProperty("skill");
+                Object property = activeMenu.getProperty("skill");
+                assert (null != property);
+                Skill skill = (Skill) property;
                 return TextUtil.replace(Lang.getMessage(MenuMessage.SOURCES_CLICK, locale),
                         "{skill}", skill.getDisplayName(locale));
         }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SourcesItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/SourcesItem.java
@@ -34,9 +34,7 @@ public class SourcesItem extends AbstractItem implements SingleItemProvider {
             case "sources_desc":
                 return Lang.getMessage(MenuMessage.SOURCES_DESC, locale);
             case "sources_click":
-                Object property = activeMenu.getProperty("skill");
-                assert (null != property);
-                Skill skill = (Skill) property;
+                Skill skill = getSkill(activeMenu);
                 return TextUtil.replace(Lang.getMessage(MenuMessage.SOURCES_CLICK, locale),
                         "{skill}", skill.getDisplayName(locale));
         }
@@ -46,10 +44,19 @@ public class SourcesItem extends AbstractItem implements SingleItemProvider {
     @Override
     public void onClick(Player player, InventoryClickEvent event, ItemStack item, SlotPos pos, ActiveMenu activeMenu) {
         Map<String, Object> properties = new HashMap<>();
-        properties.put("skill", activeMenu.getProperty("skill"));
+        properties.put("skill", getSkill(activeMenu));
         properties.put("items_per_page", 28);
         properties.put("sort_type", SorterItem.SortType.ASCENDING);
         properties.put("previous_menu", "level_progression");
         plugin.getMenuManager().openMenu(player, "sources", properties, 0);
     }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
+    }
+
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/StaticSkillItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/StaticSkillItem.java
@@ -17,11 +17,17 @@ public class StaticSkillItem extends AbstractSkillItem {
 
     @Override
     public Set<Skill> getDefinedContexts(Player player, ActiveMenu activeMenu) {
-        Object property = activeMenu.getProperty("skill");
-        Skill skill = (Skill) property;
         Set<Skill> skills = new HashSet<>();
-        skills.add(skill);
+        skills.add(getSkill(activeMenu));
         return skills;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/UnlockedItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/UnlockedItem.java
@@ -24,7 +24,9 @@ public class UnlockedItem extends SkillLevelItem {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer position) {
         Locale locale = plugin.getLang().getLocale(player);
-        Skill skill = (Skill) activeMenu.getProperty("skill");
+        Object property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
         int level = getLevel(activeMenu, position);
         switch (placeholder) {
             case "level_unlocked":

--- a/src/main/java/com/archyx/aureliumskills/menus/levelprogression/UnlockedItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/levelprogression/UnlockedItem.java
@@ -24,9 +24,7 @@ public class UnlockedItem extends SkillLevelItem {
     @Override
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType placeholderType, Integer position) {
         Locale locale = plugin.getLang().getLocale(player);
-        Object property = activeMenu.getProperty("skill");
-        assert (null != property);
-        Skill skill = (Skill) property;
+        Skill skill = getSkill(activeMenu);
         int level = getLevel(activeMenu, position);
         switch (placeholder) {
             case "level_unlocked":
@@ -47,23 +45,30 @@ public class UnlockedItem extends SkillLevelItem {
 
     @Override
     public Set<Integer> getDefinedContexts(Player player, ActiveMenu activeMenu) {
+        Set<Integer> levels = new HashSet<>();
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        if (playerData != null) {
-            Skill skill = (Skill) activeMenu.getProperty("skill");
-            int level = playerData.getSkillLevel(skill);
-            int itemsPerPage = getItemsPerPage(activeMenu);
-            int currentPage = activeMenu.getCurrentPage();
-            Set<Integer> levels = new HashSet<>();
-            for (int i = 0; i < itemsPerPage; i++) {
-                if (2 + currentPage * itemsPerPage + i <= level) {
-                    levels.add(2 + i);
-                } else {
-                    break;
-                }
-            }
+        if (playerData == null)
             return levels;
+        Skill skill = getSkill(activeMenu);
+        int level = playerData.getSkillLevel(skill);
+        int itemsPerPage = getItemsPerPage(activeMenu);
+        int currentPage = activeMenu.getCurrentPage();
+        for (int i = 0; i < itemsPerPage; i++) {
+            if (2 + currentPage * itemsPerPage + i <= level) {
+                levels.add(2 + i);
+            } else {
+                break;
+            }
         }
-        return new HashSet<>();
+        return levels;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/skills/ClickableSkillItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/skills/ClickableSkillItem.java
@@ -43,8 +43,7 @@ public class ClickableSkillItem extends AbstractSkillItem {
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu, Skill skill) {
         if (OptionL.isEnabled(skill)) {
             return baseItem;
-        } else {
-            return null; // Hide item if skill is disabled
         }
+        return null; // Hide item if skill is disabled
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/skills/SkillsMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/skills/SkillsMenu.java
@@ -17,12 +17,7 @@ public class SkillsMenu extends AbstractMenu implements MenuProvider {
     }
 
     @Override
-    public void onOpen(Player player, ActiveMenu menu) {
-
-    }
-
-    @Override
-    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu menu) {
+    public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu) {
         Locale locale = plugin.getLang().getLocale(player);
         if (placeholder.equals("skills_menu_title")) {
             return Lang.getMessage(MenuMessage.SKILLS_MENU_TITLE, locale);

--- a/src/main/java/com/archyx/aureliumskills/menus/skills/StatsItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/skills/StatsItem.java
@@ -49,8 +49,10 @@ public class StatsItem extends AbstractItem implements SingleItemProvider {
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu) {
         if (baseItem.getItemMeta() instanceof SkullMeta) {
             SkullMeta meta = (SkullMeta) baseItem.getItemMeta();
-            meta.setOwningPlayer(Bukkit.getOfflinePlayer(player.getUniqueId()));
-            baseItem.setItemMeta(meta);
+            if (meta != null) {
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer(player.getUniqueId()));
+                baseItem.setItemMeta(meta);
+            }
         }
         return baseItem;
     }

--- a/src/main/java/com/archyx/aureliumskills/menus/sources/SorterItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/sources/SorterItem.java
@@ -38,7 +38,7 @@ public class SorterItem extends AbstractItem implements SingleItemProvider {
     @Override
     public void onClick(Player player, InventoryClickEvent event, ItemStack item, SlotPos pos, ActiveMenu activeMenu) {
         SortType[] sortTypes = SortType.values();
-        SortType currentType = (SortType) activeMenu.getProperty("sort_type");
+        SortType currentType = getSortType(activeMenu);
         // Get the index of the current sort type in the array
         int currentTypeIndex = 0;
         for (int i = 0; i < sortTypes.length; i++) {
@@ -62,7 +62,7 @@ public class SorterItem extends AbstractItem implements SingleItemProvider {
 
     private String getSortedTypesLore(Locale locale, ActiveMenu activeMenu) {
         StringBuilder builder = new StringBuilder();
-        SortType selectedSort = (SortType) activeMenu.getProperty("sort_type");
+        SortType selectedSort = getSortType(activeMenu);
         for (SortType sortType : SortType.values()) {
             String typeString = TextUtil.replace(Lang.getMessage(MenuMessage.SORT_TYPE, locale)
                     , "{type_name}", Lang.getMessage(MenuMessage.valueOf(sortType.toString()), locale));
@@ -96,6 +96,14 @@ public class SorterItem extends AbstractItem implements SingleItemProvider {
             }
         }
 
+    }
+
+    private SortType getSortType(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("sort_type");
+        if (!(property instanceof SortType)) {
+            throw new IllegalArgumentException("Could not get menu sort_type property");
+        }
+        return (SortType) property;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/sources/SourceItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/sources/SourceItem.java
@@ -52,6 +52,7 @@ public class SourceItem extends AbstractItem implements TemplateItemProvider<Sou
                 }
             case "multiplied_xp":
                 Skill skill = (Skill) activeMenu.getProperty("skill");
+                assert (null != skill);
                 double multiplier = getMultiplier(player, skill);
                 if (multiplier > 1.0) {
                     String unit = source.getUnitName();
@@ -68,6 +69,7 @@ public class SourceItem extends AbstractItem implements TemplateItemProvider<Sou
                 }
             case "multiplied_desc":
                 Skill skill1 = (Skill) activeMenu.getProperty("skill");
+                assert (null != skill1);
                 if (getMultiplier(player, skill1) > 1.0) {
                     return Lang.getMessage(MenuMessage.MULTIPLIED_DESC, locale);
                 } else {
@@ -80,9 +82,16 @@ public class SourceItem extends AbstractItem implements TemplateItemProvider<Sou
     @Override
     public Set<Source> getDefinedContexts(Player player, ActiveMenu activeMenu) {
         // Gets the needed properties from the menu
-        SortType sortType = (SortType) activeMenu.getProperty("sort_type");
-        Skill skill = (Skill) activeMenu.getProperty("skill");
-        int itemsPerPage = (Integer) activeMenu.getProperty("items_per_page");
+        Object property = activeMenu.getProperty("sort_type");
+        assert (null != property);
+        SortType sortType = (SortType) property;
+        property = activeMenu.getProperty("skill");
+        assert (null != property);
+        Skill skill = (Skill) property;
+        assert (null != skill);
+        property = activeMenu.getProperty("items_per_page");
+        assert (null != property);
+        int itemsPerPage = (Integer) property;
         int page = activeMenu.getCurrentPage();
         Locale locale = plugin.getLang().getLocale(player);
         // Sort the sources in the skill by the selected sort type

--- a/src/main/java/com/archyx/aureliumskills/menus/sources/SourcesMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/sources/SourcesMenu.java
@@ -23,7 +23,9 @@ public class SourcesMenu extends AbstractMenu implements MenuProvider {
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu) {
         Locale locale = plugin.getLang().getLocale(player);
         if (placeholder.equals("sources_title")) {
-            Skill skill = (Skill) activeMenu.getProperty("skill");
+            Object property = activeMenu.getProperty("skill");
+            assert (null != property);
+            Skill skill = (Skill) property;
             return TextUtil.replace(Lang.getMessage(MenuMessage.SOURCES_TITLE, locale),
                     "{skill}", skill.getDisplayName(locale),
                     "{current_page}", String.valueOf(activeMenu.getCurrentPage() + 1),
@@ -35,7 +37,9 @@ public class SourcesMenu extends AbstractMenu implements MenuProvider {
     @Override
     public int getPages(Player player, ActiveMenu activeMenu) {
         Skill skill = (Skill) activeMenu.getProperty("skill");
-        int itemsPerPage = (Integer) activeMenu.getProperty("items_per_page");
+        Object property = activeMenu.getProperty("items_per_page");
+        assert (null != property);
+        int itemsPerPage = (Integer) property;
         Source[] sources = plugin.getSourceRegistry().values(skill);
         return (sources.length - 1) / itemsPerPage + 1;
     }

--- a/src/main/java/com/archyx/aureliumskills/menus/sources/SourcesMenu.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/sources/SourcesMenu.java
@@ -23,9 +23,7 @@ public class SourcesMenu extends AbstractMenu implements MenuProvider {
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu) {
         Locale locale = plugin.getLang().getLocale(player);
         if (placeholder.equals("sources_title")) {
-            Object property = activeMenu.getProperty("skill");
-            assert (null != property);
-            Skill skill = (Skill) property;
+            Skill skill = getSkill(activeMenu);
             return TextUtil.replace(Lang.getMessage(MenuMessage.SOURCES_TITLE, locale),
                     "{skill}", skill.getDisplayName(locale),
                     "{current_page}", String.valueOf(activeMenu.getCurrentPage() + 1),
@@ -36,11 +34,28 @@ public class SourcesMenu extends AbstractMenu implements MenuProvider {
 
     @Override
     public int getPages(Player player, ActiveMenu activeMenu) {
-        Skill skill = (Skill) activeMenu.getProperty("skill");
-        Object property = activeMenu.getProperty("items_per_page");
-        assert (null != property);
-        int itemsPerPage = (Integer) property;
+        Skill skill = getSkill(activeMenu);
+        int itemsPerPage = getItemsPerPage(activeMenu);
         Source[] sources = plugin.getSourceRegistry().values(skill);
         return (sources.length - 1) / itemsPerPage + 1;
+    }
+
+    protected int getItemsPerPage(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("items_per_page");
+        int itemsPerPage;
+        if (property instanceof Integer) {
+            itemsPerPage = (Integer) property;
+        } else {
+            itemsPerPage = 24;
+        }
+        return itemsPerPage;
+    }
+
+    private Skill getSkill(ActiveMenu activeMenu) {
+        Object property = activeMenu.getProperty("skill");
+        if (!(property instanceof Skill)) {
+            throw new IllegalArgumentException("Could not get menu skill property");
+        }
+        return (Skill) property;
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/menus/stats/SkullItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/stats/SkullItem.java
@@ -49,8 +49,10 @@ public class SkullItem extends AbstractItem implements SingleItemProvider {
     public ItemStack onItemModify(ItemStack baseItem, Player player, ActiveMenu activeMenu) {
         if (baseItem.getItemMeta() instanceof SkullMeta) {
             SkullMeta meta = (SkullMeta) baseItem.getItemMeta();
-            meta.setOwningPlayer(Bukkit.getOfflinePlayer(player.getUniqueId()));
-            baseItem.setItemMeta(meta);
+            if (meta != null) {
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer(player.getUniqueId()));
+                baseItem.setItemMeta(meta);
+            }
         }
         return baseItem;
     }

--- a/src/main/java/com/archyx/aureliumskills/menus/stats/SkullItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/stats/SkullItem.java
@@ -32,7 +32,6 @@ public class SkullItem extends AbstractItem implements SingleItemProvider {
         }
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
-            // Handle each stat entry
             Stat stat = plugin.getStatRegistry().getStat(placeholder);
             if (stat != null) {
                 return TextUtil.replace(Lang.getMessage(MenuMessage.PLAYER_STAT_ENTRY, locale),

--- a/src/main/java/com/archyx/aureliumskills/menus/stats/StatItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/stats/StatItem.java
@@ -42,9 +42,8 @@ public class StatItem extends AbstractItem implements TemplateItemProvider<Stat>
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, Stat stat) {
         Locale locale = plugin.getLang().getLocale(player);
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
-        String name = stat.name();
-        assert (null != name);
-        if (playerData == null) return placeholder;
+        if (playerData == null)
+            return placeholder;
         switch (placeholder) {
             case "color":
                 return stat.getColor(locale);
@@ -59,7 +58,7 @@ public class StatItem extends AbstractItem implements TemplateItemProvider<Stat>
                         "{color}", stat.getColor(locale),
                         "{level}", NumberUtil.format1(playerData.getStatLevel(stat)));
             case "descriptors":
-                switch (name.toLowerCase(Locale.ROOT)) {
+                switch (stat.name().toLowerCase(Locale.ROOT)) {
                     case "strength":
                         return getStrengthDescriptors(playerData, locale);
                     case "health":

--- a/src/main/java/com/archyx/aureliumskills/menus/stats/StatItem.java
+++ b/src/main/java/com/archyx/aureliumskills/menus/stats/StatItem.java
@@ -42,6 +42,8 @@ public class StatItem extends AbstractItem implements TemplateItemProvider<Stat>
     public String onPlaceholderReplace(String placeholder, Player player, ActiveMenu activeMenu, PlaceholderType type, Stat stat) {
         Locale locale = plugin.getLang().getLocale(player);
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
+        String name = stat.name();
+        assert (null != name);
         if (playerData == null) return placeholder;
         switch (placeholder) {
             case "color":
@@ -57,7 +59,7 @@ public class StatItem extends AbstractItem implements TemplateItemProvider<Stat>
                         "{color}", stat.getColor(locale),
                         "{level}", NumberUtil.format1(playerData.getStatLevel(stat)));
             case "descriptors":
-                switch (stat.name().toLowerCase(Locale.ROOT)) {
+                switch (name.toLowerCase(Locale.ROOT)) {
                     case "strength":
                         return getStrengthDescriptors(playerData, locale);
                     case "health":

--- a/src/main/java/com/archyx/aureliumskills/modifier/ArmorModifierListener.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/ArmorModifierListener.java
@@ -73,24 +73,24 @@ public class ArmorModifierListener implements Listener {
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData != null) {
             // Equip
-            if (event.getNewArmorPiece() != null && event.getNewArmorPiece().getType() != Material.AIR) {
-                ItemStack item = event.getNewArmorPiece();
-                if (requirements.meetsRequirements(ModifierType.ARMOR, item, player)) {
-                    for (StatModifier modifier : modifiers.getModifiers(ModifierType.ARMOR, item)) {
+            ItemStack armorPiece = event.getNewArmorPiece();
+            if (armorPiece != null && armorPiece.getType() != Material.AIR) {
+                if (requirements.meetsRequirements(ModifierType.ARMOR, armorPiece, player)) {
+                    for (StatModifier modifier : modifiers.getModifiers(ModifierType.ARMOR, armorPiece)) {
                         playerData.addStatModifier(modifier);
                     }
-                    for (Multiplier multiplier : multipliers.getMultipliers(ModifierType.ARMOR, item)) {
+                    for (Multiplier multiplier : multipliers.getMultipliers(ModifierType.ARMOR, armorPiece)) {
                         playerData.addMultiplier(multiplier);
                     }
                 }
             }
             // Un-equip
-            if (event.getOldArmorPiece() != null && event.getOldArmorPiece().getType() != Material.AIR) {
-                ItemStack item = event.getOldArmorPiece();
-                for (StatModifier modifier : modifiers.getModifiers(ModifierType.ARMOR, item)) {
+            armorPiece = event.getOldArmorPiece();
+            if (armorPiece != null && armorPiece.getType() != Material.AIR) {
+                for (StatModifier modifier : modifiers.getModifiers(ModifierType.ARMOR, armorPiece)) {
                     playerData.removeStatModifier(modifier.getName());
                 }
-                for (Multiplier multiplier : multipliers.getMultipliers(ModifierType.ARMOR, item)) {
+                for (Multiplier multiplier : multipliers.getMultipliers(ModifierType.ARMOR, armorPiece)) {
                     playerData.removeMultiplier(multiplier.getName());
                 }
             }
@@ -116,6 +116,8 @@ public class ArmorModifierListener implements Listener {
                         } else if (stored.equals(wearing)) { // Don't check if stored and wearing are the same item
                             continue;
                         }
+
+                        assert (stored != null);
 
                         Set<Stat> statsToReload = new HashSet<>();
                         // Remove modifiers and multipliers that are on stored item from player

--- a/src/main/java/com/archyx/aureliumskills/modifier/ArmorModifierListener.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/ArmorModifierListener.java
@@ -116,8 +116,7 @@ public class ArmorModifierListener implements Listener {
                         } else if (stored.equals(wearing)) { // Don't check if stored and wearing are the same item
                             continue;
                         }
-
-                        assert (stored != null);
+                        assert (null != stored);
 
                         Set<Stat> statsToReload = new HashSet<>();
                         // Remove modifiers and multipliers that are on stored item from player

--- a/src/main/java/com/archyx/aureliumskills/modifier/Modifiers.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Modifiers.java
@@ -134,7 +134,9 @@ public class Modifiers extends NBTAPIUser {
     public void addLore(ModifierType type, ItemStack item, Stat stat, double value, Locale locale) {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            List<String> lore = Objects.requireNonNullElseGet(meta.getLore(), LinkedList::new);
+            List<String> lore = meta.getLore();
+            if (lore == null)
+                lore = new ArrayList<>();
             CommandMessage message;
             if (value >= 0) {
                 message = CommandMessage.valueOf(type.name() + "_MODIFIER_ADD_LORE");

--- a/src/main/java/com/archyx/aureliumskills/modifier/Modifiers.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Modifiers.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class Modifiers extends NBTAPIUser {
 
@@ -28,7 +29,9 @@ public class Modifiers extends NBTAPIUser {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getModifiersTypeCompound(nbtItem, type);
-        compound.setDouble(getName(stat), value);
+        String name = getName(stat);
+        assert (null != name);
+        compound.setDouble(name, value);
         return nbtItem.getItem();
     }
 
@@ -40,7 +43,9 @@ public class Modifiers extends NBTAPIUser {
             if (legacyModifiers.size() > 0) {
                 NBTCompound compound = ItemUtils.getModifiersTypeCompound(nbtItem, type);
                 for (StatModifier modifier : legacyModifiers) {
-                    compound.setDouble(getName(modifier.getStat()), modifier.getValue());
+                    String name = getName(modifier.getStat());
+                    assert (null != name);
+                    compound.setDouble(name, modifier.getValue());
                 }
                 for (String key : nbtItem.getKeys()) {
                     if (key.startsWith("skillsmodifier-" + type.name().toLowerCase(Locale.ENGLISH) + "-")) {
@@ -56,7 +61,9 @@ public class Modifiers extends NBTAPIUser {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getModifiersTypeCompound(nbtItem, type);
-        compound.removeKey(getName(stat));
+        String name = getName(stat);
+        assert (null != name);
+        compound.removeKey(name);
         ItemUtils.removeParentCompounds(compound);
         return nbtItem.getItem();
     }
@@ -127,24 +134,20 @@ public class Modifiers extends NBTAPIUser {
     public void addLore(ModifierType type, ItemStack item, Stat stat, double value, Locale locale) {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            List<String> lore;
-            if (meta.getLore() != null) {
-                if (meta.getLore().size() > 0) lore = meta.getLore();
-                else lore = new LinkedList<>();
-            }
-            else {
-                lore = new LinkedList<>();
-            }
+            List<String> lore = Objects.requireNonNullElseGet(meta.getLore(), LinkedList::new);
             CommandMessage message;
             if (value >= 0) {
                 message = CommandMessage.valueOf(type.name() + "_MODIFIER_ADD_LORE");
             } else {
                 message = CommandMessage.valueOf(type.name() + "_MODIFIER_ADD_LORE_SUBTRACT");
             }
-            lore.add(0, TextUtil.replace(Lang.getMessage(message, locale),
-                    "{stat}", stat.getDisplayName(locale),
-                    "{value}", NumberUtil.format1(Math.abs(value)),
-                    "{color}", stat.getColor(locale)));
+
+            String t =TextUtil.replace(Lang.getMessage(message, locale),
+                "{stat}", stat.getDisplayName(locale),
+                "{value}", NumberUtil.format1(Math.abs(value)),
+                "{color}", stat.getColor(locale));
+            assert (null != t);
+            lore.add(0, t);
             meta.setLore(lore);
         }
         item.setItemMeta(meta);
@@ -154,14 +157,18 @@ public class Modifiers extends NBTAPIUser {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             List<String> lore = meta.getLore();
-            if (lore != null && lore.size() > 0) lore.removeIf(line -> line.contains(stat.getDisplayName(locale)));
-            meta.setLore(lore);
+            if (lore != null) {
+                lore.removeIf(line -> line.contains(stat.getDisplayName(locale)));
+                meta.setLore(lore);
+            }
         }
         item.setItemMeta(meta);
     }
 
     private String getName(Stat stat) {
-        return TextUtil.capitalize(stat.name().toLowerCase(Locale.ENGLISH));
+        String name = stat.name();
+        assert (null != name);
+        return TextUtil.capitalize(name.toLowerCase(Locale.ENGLISH));
     }
     
 }

--- a/src/main/java/com/archyx/aureliumskills/modifier/Modifiers.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Modifiers.java
@@ -14,10 +14,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 public class Modifiers extends NBTAPIUser {
 
@@ -29,9 +27,7 @@ public class Modifiers extends NBTAPIUser {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getModifiersTypeCompound(nbtItem, type);
-        String name = getName(stat);
-        assert (null != name);
-        compound.setDouble(name, value);
+        compound.setDouble(getName(stat), value);
         return nbtItem.getItem();
     }
 
@@ -43,9 +39,7 @@ public class Modifiers extends NBTAPIUser {
             if (legacyModifiers.size() > 0) {
                 NBTCompound compound = ItemUtils.getModifiersTypeCompound(nbtItem, type);
                 for (StatModifier modifier : legacyModifiers) {
-                    String name = getName(modifier.getStat());
-                    assert (null != name);
-                    compound.setDouble(name, modifier.getValue());
+                    compound.setDouble(getName(modifier.getStat()), modifier.getValue());
                 }
                 for (String key : nbtItem.getKeys()) {
                     if (key.startsWith("skillsmodifier-" + type.name().toLowerCase(Locale.ENGLISH) + "-")) {
@@ -61,9 +55,7 @@ public class Modifiers extends NBTAPIUser {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getModifiersTypeCompound(nbtItem, type);
-        String name = getName(stat);
-        assert (null != name);
-        compound.removeKey(name);
+        compound.removeKey(getName(stat));
         ItemUtils.removeParentCompounds(compound);
         return nbtItem.getItem();
     }
@@ -143,13 +135,10 @@ public class Modifiers extends NBTAPIUser {
             } else {
                 message = CommandMessage.valueOf(type.name() + "_MODIFIER_ADD_LORE_SUBTRACT");
             }
-
-            String t =TextUtil.replace(Lang.getMessage(message, locale),
-                "{stat}", stat.getDisplayName(locale),
-                "{value}", NumberUtil.format1(Math.abs(value)),
-                "{color}", stat.getColor(locale));
-            assert (null != t);
-            lore.add(0, t);
+            lore.add(0, TextUtil.replace(Lang.getMessage(message, locale),
+                    "{stat}", stat.getDisplayName(locale),
+                    "{value}", NumberUtil.format1(Math.abs(value)),
+                    "{color}", stat.getColor(locale)));
             meta.setLore(lore);
         }
         item.setItemMeta(meta);
@@ -168,9 +157,7 @@ public class Modifiers extends NBTAPIUser {
     }
 
     private String getName(Stat stat) {
-        String name = stat.name();
-        assert (null != name);
-        return TextUtil.capitalize(name.toLowerCase(Locale.ENGLISH));
+        return TextUtil.capitalize(stat.name().toLowerCase(Locale.ENGLISH));
     }
     
 }

--- a/src/main/java/com/archyx/aureliumskills/modifier/Multiplier.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Multiplier.java
@@ -1,7 +1,6 @@
 package com.archyx.aureliumskills.modifier;
 
 import com.archyx.aureliumskills.skills.Skill;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -11,7 +10,7 @@ public class Multiplier {
     private final Skill skill;
     private final double value; // The value represents the percent more XP gained
 
-    public Multiplier(String name, @Nullable Skill skill, double value) {
+    public Multiplier(String name, Skill skill, double value) {
         this.name = name;
         this.value = value;
         this.skill = skill;
@@ -21,7 +20,6 @@ public class Multiplier {
         return name;
     }
 
-    @Nullable
     public Skill getSkill() {
         return skill;
     }

--- a/src/main/java/com/archyx/aureliumskills/modifier/Multipliers.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Multipliers.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class Multipliers extends NBTAPIUser {
 
@@ -88,16 +89,7 @@ public class Multipliers extends NBTAPIUser {
     public void addLore(ModifierType type, ItemStack item, Skill skill, double value, Locale locale) {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            List<String> lore;
-            if (meta.getLore() != null) {
-                if (meta.getLore().size() > 0) {
-                    lore = meta.getLore();
-                } else {
-                    lore = new LinkedList<>();
-                }
-            } else {
-                lore = new LinkedList<>();
-            }
+            List<String> lore = Objects.requireNonNullElseGet(meta.getLore(), LinkedList::new);
             if (skill != null) { // Skill multiplier
                 CommandMessage message;
                 if (value >= 0) {
@@ -108,9 +100,11 @@ public class Multipliers extends NBTAPIUser {
                 if (lore.size() > 0) {
                     lore.add(" ");
                 }
-                lore.add(TextUtil.replace(Lang.getMessage(message, locale),
+                String t = TextUtil.replace(Lang.getMessage(message, locale),
                         "{skill}", skill.getDisplayName(locale),
-                        "{value}", NumberUtil.format1(Math.abs(value))));
+                        "{value}", NumberUtil.format1(Math.abs(value)));
+                assert (null != t);
+                lore.add(t);
             } else { // Global multiplier
                 CommandMessage message;
                 if (value >= 0) {
@@ -121,8 +115,10 @@ public class Multipliers extends NBTAPIUser {
                 if (lore.size() > 0) {
                     lore.add(" ");
                 }
-                lore.add(TextUtil.replace(Lang.getMessage(message, locale),
-                        "{value}", NumberUtil.format1(Math.abs(value))));
+                String t = TextUtil.replace(Lang.getMessage(message, locale),
+                        "{value}", NumberUtil.format1(Math.abs(value)));
+                assert (null != t);
+                lore.add(t);
             }
             meta.setLore(lore);
         }
@@ -131,7 +127,9 @@ public class Multipliers extends NBTAPIUser {
 
     private String getNBTName(@Nullable Skill skill) {
         if (skill != null) {
-            return TextUtil.capitalize(skill.toString().toLowerCase(Locale.ROOT));
+            String name = TextUtil.capitalize(skill.toString().toLowerCase(Locale.ROOT));
+            assert (null != name);
+            return name;
         } else {
             return "Global";
         }

--- a/src/main/java/com/archyx/aureliumskills/modifier/Multipliers.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Multipliers.java
@@ -14,13 +14,10 @@ import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTItem;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 public class Multipliers extends NBTAPIUser {
 
@@ -58,7 +55,7 @@ public class Multipliers extends NBTAPIUser {
         return multipliers;
     }
 
-    public ItemStack addMultiplier(ModifierType type, ItemStack item, @Nullable Skill skill, double value) {
+    public ItemStack addMultiplier(ModifierType type, ItemStack item, Skill skill, double value) {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getMultipliersTypeCompound(nbtItem, type);
@@ -66,7 +63,7 @@ public class Multipliers extends NBTAPIUser {
         return nbtItem.getItem();
     }
 
-    public ItemStack removeMultiplier(ModifierType type, ItemStack item, @Nullable Skill skill) {
+    public ItemStack removeMultiplier(ModifierType type, ItemStack item, Skill skill) {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getMultipliersTypeCompound(nbtItem, type);
@@ -102,11 +99,9 @@ public class Multipliers extends NBTAPIUser {
                 if (lore.size() > 0) {
                     lore.add(" ");
                 }
-                String t = TextUtil.replace(Lang.getMessage(message, locale),
+                lore.add(TextUtil.replace(Lang.getMessage(message, locale),
                         "{skill}", skill.getDisplayName(locale),
-                        "{value}", NumberUtil.format1(Math.abs(value)));
-                assert (null != t);
-                lore.add(t);
+                        "{value}", NumberUtil.format1(Math.abs(value))));
             } else { // Global multiplier
                 CommandMessage message;
                 if (value >= 0) {
@@ -117,21 +112,17 @@ public class Multipliers extends NBTAPIUser {
                 if (lore.size() > 0) {
                     lore.add(" ");
                 }
-                String t = TextUtil.replace(Lang.getMessage(message, locale),
-                        "{value}", NumberUtil.format1(Math.abs(value)));
-                assert (null != t);
-                lore.add(t);
+                lore.add(TextUtil.replace(Lang.getMessage(message, locale),
+                        "{value}", NumberUtil.format1(Math.abs(value))));
             }
             meta.setLore(lore);
         }
         item.setItemMeta(meta);
     }
 
-    private String getNBTName(@Nullable Skill skill) {
+    private String getNBTName(Skill skill) {
         if (skill != null) {
-            String name = TextUtil.capitalize(skill.toString().toLowerCase(Locale.ROOT));
-            assert (null != name);
-            return name;
+            return TextUtil.capitalize(skill.toString().toLowerCase(Locale.ROOT));
         } else {
             return "Global";
         }

--- a/src/main/java/com/archyx/aureliumskills/modifier/Multipliers.java
+++ b/src/main/java/com/archyx/aureliumskills/modifier/Multipliers.java
@@ -89,7 +89,9 @@ public class Multipliers extends NBTAPIUser {
     public void addLore(ModifierType type, ItemStack item, Skill skill, double value, Locale locale) {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            List<String> lore = Objects.requireNonNullElseGet(meta.getLore(), LinkedList::new);
+            List<String> lore = meta.getLore();
+            if (lore == null)
+                lore = new ArrayList<>();
             if (skill != null) { // Skill multiplier
                 CommandMessage message;
                 if (value >= 0) {

--- a/src/main/java/com/archyx/aureliumskills/region/Region.java
+++ b/src/main/java/com/archyx/aureliumskills/region/Region.java
@@ -1,7 +1,6 @@
 package com.archyx.aureliumskills.region;
 
 import org.bukkit.World;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,7 +36,6 @@ public class Region {
         return z;
     }
 
-    @Nullable
     public ChunkData getChunkData(ChunkCoordinate chunkCoordinate) {
         return chunks.get(chunkCoordinate);
     }

--- a/src/main/java/com/archyx/aureliumskills/region/RegionBlockListener.java
+++ b/src/main/java/com/archyx/aureliumskills/region/RegionBlockListener.java
@@ -9,6 +9,7 @@ import com.archyx.aureliumskills.skills.foraging.ForagingSource;
 import com.archyx.aureliumskills.skills.mining.MiningSource;
 import com.archyx.aureliumskills.skills.sorcery.SorcerySource;
 import com.archyx.aureliumskills.source.SourceManager;
+import com.archyx.aureliumskills.support.WorldGuardSupport;
 import com.archyx.aureliumskills.util.block.BlockFaceUtil;
 import com.cryptomorin.xseries.XBlock;
 import com.cryptomorin.xseries.XMaterial;
@@ -66,8 +67,9 @@ public class RegionBlockListener implements Listener {
             return;
         }
         // Checks if region is blocked
-        if (plugin.isWorldGuardEnabled()) {
-            if (plugin.getWorldGuardSupport().isInBlockedCheckRegion(event.getBlock().getLocation())) {
+        WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+        if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+            if (worldGuardSupport.isInBlockedCheckRegion(event.getBlock().getLocation())) {
                 return;
             }
         }

--- a/src/main/java/com/archyx/aureliumskills/region/RegionManager.java
+++ b/src/main/java/com/archyx/aureliumskills/region/RegionManager.java
@@ -144,6 +144,8 @@ public class RegionManager {
             chunkData = new ChunkData(region, chunkCoordinate.getX(), chunkCoordinate.getZ());
         }
         NBTCompoundList placedBlocks = compound.getCompoundList("placed_blocks");
+        if (placedBlocks == null)
+            return;
         for (NBTListCompound block : placedBlocks) {
             int x = block.getInteger("x");
             int y = block.getInteger("y");
@@ -188,6 +190,8 @@ public class RegionManager {
     private void saveChunk(NBTFile nbtFile, ChunkData chunkData) {
         NBTCompound chunk = nbtFile.getOrCreateCompound("chunk[" + chunkData.getX() + "," + chunkData.getZ() + "]");
         NBTCompoundList placedBlocks = chunk.getCompoundList("placed_blocks");
+        if (placedBlocks == null)
+            return;
         placedBlocks.clear(); // Clears list of block positions to account for removed positions
         // Adds all positions to nbt compound list
         for (BlockPosition block : chunkData.getPlacedBlocks().keySet()) {

--- a/src/main/java/com/archyx/aureliumskills/region/RegionManager.java
+++ b/src/main/java/com/archyx/aureliumskills/region/RegionManager.java
@@ -4,11 +4,11 @@ import com.archyx.aureliumskills.AureliumSkills;
 import de.tr7zw.changeme.nbtapi.*;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -24,7 +24,6 @@ public class RegionManager {
         this.saving = false;
     }
 
-    @Nullable
     public Region getRegion(RegionCoordinate regionCoordinate) {
         return regions.get(regionCoordinate);
     }
@@ -120,7 +119,7 @@ public class RegionManager {
                         byte chunkX = Byte.parseByte(key.substring(key.indexOf("[") + 1, commaIndex));
                         byte chunkZ = Byte.parseByte(key.substring(commaIndex + 1, key.lastIndexOf("]")));
                         // Load chunk
-                        NBTCompound chunkCompound = nbtFile.getCompound(key);
+                        NBTCompound chunkCompound = Objects.requireNonNull(nbtFile.getCompound(key));
                         ChunkCoordinate chunkCoordinate = new ChunkCoordinate(chunkX, chunkZ);
                         loadChunk(region, chunkCoordinate, chunkCompound);
                     }

--- a/src/main/java/com/archyx/aureliumskills/requirement/RequirementListener.java
+++ b/src/main/java/com/archyx/aureliumskills/requirement/RequirementListener.java
@@ -140,7 +140,7 @@ public class RequirementListener implements Listener {
         ItemStack item = event.getItem();
         if (item == null) return;
         if (item.getType() == Material.AIR) return;
-        checkItemRequirements(event.getPlayer(), event.getItem(), event);
+        checkItemRequirements(event.getPlayer(), item, event);
     }
 
     private void checkItemRequirements(Player player, ItemStack item, Cancellable event) {

--- a/src/main/java/com/archyx/aureliumskills/requirement/RequirementListener.java
+++ b/src/main/java/com/archyx/aureliumskills/requirement/RequirementListener.java
@@ -66,14 +66,17 @@ public class RequirementListener implements Listener {
         // Build requirements message that shows skills and levels
         StringBuilder requirementsString = new StringBuilder();
         Map<Skill, Integer> requirementMap = requirements.getRequirements(modifierType, item);
+        String m;
         for (Map.Entry<Skill, Integer> entry : requirementMap.entrySet()) {
-            requirementsString.append(TextUtil.replace(Lang.getMessage(entryMessage, locale),
-                    "{skill}", entry.getKey().getDisplayName(locale), "{level}", RomanNumber.toRoman(entry.getValue())));
+            m = TextUtil.replace(Lang.getMessage(entryMessage, locale),
+                    "{skill}", entry.getKey().getDisplayName(locale), "{level}", RomanNumber.toRoman(entry.getValue()));
+            requirementsString.append(m);
         }
         Map<Skill, Integer> globalRequirementMap = requirements.getGlobalRequirements(modifierType, item);
         for (Map.Entry<Skill, Integer> entry : globalRequirementMap.entrySet()) {
-            requirementsString.append(TextUtil.replace(Lang.getMessage(entryMessage, locale),
-                    "{skill}", entry.getKey().getDisplayName(locale), "{level}", RomanNumber.toRoman(entry.getValue())));
+            m = TextUtil.replace(Lang.getMessage(entryMessage, locale),
+                    "{skill}", entry.getKey().getDisplayName(locale), "{level}", RomanNumber.toRoman(entry.getValue()));
+            requirementsString.append(m);
         }
         if (requirementsString.length() >= 2) {
             requirementsString.delete(requirementsString.length() - 2, requirementsString.length());

--- a/src/main/java/com/archyx/aureliumskills/requirement/RequirementManager.java
+++ b/src/main/java/com/archyx/aureliumskills/requirement/RequirementManager.java
@@ -81,9 +81,11 @@ public class RequirementManager implements Listener {
             @Override
             public void run() {
                 for (UUID id : errorMessageTimer.keySet()) {
-                    int timer = errorMessageTimer.get(id);
+                    Integer timer = errorMessageTimer.get(id);
+                    if (timer == null)
+                        throw new IllegalStateException("Invalid requirements tick timer index key: " + id);
                     if (timer != 0) {
-                        errorMessageTimer.put(id, errorMessageTimer.get(id) - 1);
+                        errorMessageTimer.put(id, timer - 1);
                     }
                 }
             }

--- a/src/main/java/com/archyx/aureliumskills/requirement/Requirements.java
+++ b/src/main/java/com/archyx/aureliumskills/requirement/Requirements.java
@@ -78,7 +78,9 @@ public class Requirements extends NBTAPIUser {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getRequirementsTypeCompound(nbtItem, type);
-        compound.setInteger(getName(skill), level);
+        String name = getName(skill);
+        assert (null != name);
+        compound.setInteger(name, level);
         return nbtItem.getItem();
     }
 
@@ -126,7 +128,9 @@ public class Requirements extends NBTAPIUser {
                 if (oldTypeCompound != null) {
                     NBTCompound compound = ItemUtils.getRequirementsTypeCompound(nbtItem, type);
                     for (String key : oldTypeCompound.getKeys()) {
-                        compound.setInteger(TextUtil.capitalize(key), oldTypeCompound.getInteger(key));
+                        String keyU = TextUtil.capitalize(key);
+                        assert (null != keyU);
+                        compound.setInteger(keyU, oldTypeCompound.getInteger(key));
                     }
                 }
             }
@@ -139,9 +143,8 @@ public class Requirements extends NBTAPIUser {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             String text = TextUtil.replace(Lang.getMessage(CommandMessage.valueOf(type.name() + "_REQUIREMENT_ADD_LORE"), locale), "{skill}", skill.getDisplayName(locale), "{level}", String.valueOf(level));
-            List<String> lore;
-            if (meta.hasLore()) lore = meta.getLore();
-            else lore = new ArrayList<>();
+            assert (null != text);
+            List<String> lore = meta.getLore();
             if (lore != null) {
                 lore.add(text);
                 meta.setLore(lore);

--- a/src/main/java/com/archyx/aureliumskills/requirement/Requirements.java
+++ b/src/main/java/com/archyx/aureliumskills/requirement/Requirements.java
@@ -73,14 +73,11 @@ public class Requirements extends NBTAPIUser {
         return requirements;
     }
 
-
     public ItemStack addRequirement(ModifierType type, ItemStack item, Skill skill, int level) {
         if (isNBTDisabled()) return item;
         NBTItem nbtItem = new NBTItem(item);
         NBTCompound compound = ItemUtils.getRequirementsTypeCompound(nbtItem, type);
-        String name = getName(skill);
-        assert (null != name);
-        compound.setInteger(name, level);
+        compound.setInteger(getName(skill), level);
         return nbtItem.getItem();
     }
 
@@ -128,9 +125,7 @@ public class Requirements extends NBTAPIUser {
                 if (oldTypeCompound != null) {
                     NBTCompound compound = ItemUtils.getRequirementsTypeCompound(nbtItem, type);
                     for (String key : oldTypeCompound.getKeys()) {
-                        String keyU = TextUtil.capitalize(key);
-                        assert (null != keyU);
-                        compound.setInteger(keyU, oldTypeCompound.getInteger(key));
+                        compound.setInteger(TextUtil.capitalize(key), oldTypeCompound.getInteger(key));
                     }
                 }
             }
@@ -143,7 +138,6 @@ public class Requirements extends NBTAPIUser {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             String text = TextUtil.replace(Lang.getMessage(CommandMessage.valueOf(type.name() + "_REQUIREMENT_ADD_LORE"), locale), "{skill}", skill.getDisplayName(locale), "{level}", String.valueOf(level));
-            assert (null != text);
             List<String> lore = meta.getLore();
             if (lore != null) {
                 lore.add(text);

--- a/src/main/java/com/archyx/aureliumskills/rewards/CommandReward.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/CommandReward.java
@@ -40,14 +40,17 @@ public class CommandReward extends MessagedReward {
         String executedCommand = TextUtil.replace(command, "{player}", player.getName(),
                 "{skill}", skill.toString().toLowerCase(Locale.ROOT),
                 "{level}", String.valueOf(level));
+        assert (null != executedCommand);
         if (plugin.isPlaceholderAPIEnabled()) {
             executedCommand = PlaceholderAPI.setPlaceholders(player, executedCommand);
         }
         executedCommand = TextUtil.replaceNonEscaped(executedCommand, "&", "§");
         // Executes the commands
         if (executor == CommandExecutor.CONSOLE) {
+            assert (null != executedCommand);
             Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), executedCommand);
         } else {
+            assert (null != executedCommand);
             player.performCommand(executedCommand);
         }
     }

--- a/src/main/java/com/archyx/aureliumskills/rewards/CommandReward.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/CommandReward.java
@@ -40,17 +40,14 @@ public class CommandReward extends MessagedReward {
         String executedCommand = TextUtil.replace(command, "{player}", player.getName(),
                 "{skill}", skill.toString().toLowerCase(Locale.ROOT),
                 "{level}", String.valueOf(level));
-        assert (null != executedCommand);
         if (plugin.isPlaceholderAPIEnabled()) {
             executedCommand = PlaceholderAPI.setPlaceholders(player, executedCommand);
         }
         executedCommand = TextUtil.replaceNonEscaped(executedCommand, "&", "§");
         // Executes the commands
         if (executor == CommandExecutor.CONSOLE) {
-            assert (null != executedCommand);
             Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), executedCommand);
         } else {
-            assert (null != executedCommand);
             player.performCommand(executedCommand);
         }
     }

--- a/src/main/java/com/archyx/aureliumskills/rewards/MessagedReward.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/MessagedReward.java
@@ -37,24 +37,27 @@ public abstract class MessagedReward extends Reward {
      */
     private String attemptAsMessageKey(String potentialKey, Player player, Locale locale, Skill skill, int level) {
         CustomMessageKey key = new CustomMessageKey(potentialKey);
-        String message = Lang.getMessage(key, locale);
-        if (message == null) {
-            message = potentialKey;
+        String message = potentialKey;
+        try {
+            message = Lang.getMessage(key, locale);
         }
+        catch (IllegalStateException ex) {
+            // No custom message exists when using the message as a key
+            plugin.getLogger().warning("Unknown custom message with path: " + key);
+        }
+        
         return replacePlaceholders(message, player, skill, level);
     }
 
     private String replacePlaceholders(String message, Player player, Skill skill, int level) {
-        String m = TextUtil.replace(message, "{player}", player.getName(),
+        message = TextUtil.replace(message, "{player}", player.getName(),
                 "{skill}", skill.toString().toLowerCase(Locale.ROOT),
                 "{level}", String.valueOf(level));
-        assert (null != m);
         if (plugin.isPlaceholderAPIEnabled()) {
-            m = PlaceholderAPI.setPlaceholders(player, m);
+            message = PlaceholderAPI.setPlaceholders(player, message);
         }
-        m = TextUtil.replaceNonEscaped(m, "&", "§");
-        assert (null != m);
-        return m;
+        message = TextUtil.replaceNonEscaped(message, "&", "§");
+        return message;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/rewards/MessagedReward.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/MessagedReward.java
@@ -45,14 +45,16 @@ public abstract class MessagedReward extends Reward {
     }
 
     private String replacePlaceholders(String message, Player player, Skill skill, int level) {
-        message = TextUtil.replace(message, "{player}", player.getName(),
+        String m = TextUtil.replace(message, "{player}", player.getName(),
                 "{skill}", skill.toString().toLowerCase(Locale.ROOT),
                 "{level}", String.valueOf(level));
+        assert (null != m);
         if (plugin.isPlaceholderAPIEnabled()) {
-            message = PlaceholderAPI.setPlaceholders(player, message);
+            m = PlaceholderAPI.setPlaceholders(player, m);
         }
-        message = TextUtil.replaceNonEscaped(message, "&", "§");
-        return message;
+        m = TextUtil.replaceNonEscaped(m, "&", "§");
+        assert (null != m);
+        return m;
     }
 
 }

--- a/src/main/java/com/archyx/aureliumskills/rewards/PermissionReward.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/PermissionReward.java
@@ -2,6 +2,7 @@ package com.archyx.aureliumskills.rewards;
 
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.skills.Skill;
+import com.archyx.aureliumskills.support.LuckPermsSupport;
 import org.bukkit.entity.Player;
 
 public class PermissionReward extends MessagedReward {
@@ -17,8 +18,9 @@ public class PermissionReward extends MessagedReward {
 
     @Override
     public void giveReward(Player player, Skill skill, int level) {
-        if (plugin.isLuckPermsEnabled()) {
-            plugin.getLuckPermsSupport().addPermission(player, permission, value);
+        LuckPermsSupport luckPermsSupport = plugin.getLuckPermsSupport();
+        if (plugin.isLuckPermsEnabled() && luckPermsSupport != null) {
+            luckPermsSupport.addPermission(player, permission, value);
         }
     }
 

--- a/src/main/java/com/archyx/aureliumskills/rewards/RewardManager.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/RewardManager.java
@@ -60,7 +60,7 @@ public class RewardManager {
         levelsLoaded += loadLevels(globalTable, globalConfig, globalFile);
         // Apply global rewards table to each skill reward table
         for (Map.Entry<Integer, List<Reward>> entry : globalTable.getRewardsMap().entrySet()) {
-            int level = entry.getKey();
+            Integer level = entry.getKey();
             List<Reward> rewards = entry.getValue();
             for (Skill skill : plugin.getSkillRegistry().getSkills()) {
                 RewardTable rewardTable = this.rewardTables.get(skill);

--- a/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
@@ -25,7 +25,10 @@ public class RewardTable {
     }
 
     public ImmutableList<Reward> getRewards(int level) {
-        return ImmutableList.copyOf(Objects.requireNonNullElseGet(rewards.get(level), ArrayList::new));
+        List<Reward> list = rewards.get(level);
+        if (list == null)
+            list = new ArrayList<>();
+        return ImmutableList.copyOf(list);
     }
 
     public Map<Integer, List<Reward>> getRewardsMap() {

--- a/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class RewardTable {
 
@@ -25,10 +24,7 @@ public class RewardTable {
     }
 
     public ImmutableList<Reward> getRewards(int level) {
-        List<Reward> list = rewards.get(level);
-        if (list == null)
-            list = new ArrayList<>();
-        return ImmutableList.copyOf(list);
+        return ImmutableList.copyOf(rewards.get(level));
     }
 
     public Map<Integer, List<Reward>> getRewardsMap() {

--- a/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
@@ -3,6 +3,7 @@ package com.archyx.aureliumskills.rewards;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.data.PlayerData;
 import com.archyx.aureliumskills.stats.Stat;
+import com.archyx.aureliumskills.support.LuckPermsSupport;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.entity.Player;
 
@@ -97,7 +98,8 @@ public class RewardTable {
         for (Map.Entry<Integer, ImmutableList<PermissionReward>> entry : permissionRewardMap.entrySet()) {
             int entryLevel = entry.getKey();
             for (PermissionReward reward : entry.getValue()) {
-                if (plugin.isLuckPermsEnabled()) {
+                LuckPermsSupport luckPermsSupport = plugin.getLuckPermsSupport();
+                if (plugin.isLuckPermsEnabled() && luckPermsSupport != null) {
                     // Add permission if unlocked
                     if (level >= entryLevel) {
                         plugin.getLuckPermsSupport().addPermission(player, reward.getPermission(), reward.getValue());

--- a/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/RewardTable.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class RewardTable {
 
@@ -24,7 +25,7 @@ public class RewardTable {
     }
 
     public ImmutableList<Reward> getRewards(int level) {
-        return ImmutableList.copyOf(rewards.getOrDefault(level, new ArrayList<>()));
+        return ImmutableList.copyOf(Objects.requireNonNullElseGet(rewards.get(level), ArrayList::new));
     }
 
     public Map<Integer, List<Reward>> getRewardsMap() {

--- a/src/main/java/com/archyx/aureliumskills/rewards/builder/CommandRewardBuilder.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/builder/CommandRewardBuilder.java
@@ -4,7 +4,8 @@ import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.commands.CommandExecutor;
 import com.archyx.aureliumskills.rewards.CommandReward;
 import com.archyx.aureliumskills.rewards.Reward;
-import com.archyx.aureliumskills.util.misc.Validate;
+
+import java.util.Objects;
 
 public class CommandRewardBuilder extends MessagedRewardBuilder {
 
@@ -40,8 +41,7 @@ public class CommandRewardBuilder extends MessagedRewardBuilder {
 
     @Override
     public Reward build() {
-        Validate.notNull(command, "You must specify a command");
-        assert (null != command);
+        Objects.requireNonNull(command, "You must specify a command");
         return new CommandReward(plugin, menuMessage, chatMessage, executor, command, revertExecutor, revertCommand);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/rewards/builder/CommandRewardBuilder.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/builder/CommandRewardBuilder.java
@@ -41,6 +41,7 @@ public class CommandRewardBuilder extends MessagedRewardBuilder {
     @Override
     public Reward build() {
         Validate.notNull(command, "You must specify a command");
+        assert (null != command);
         return new CommandReward(plugin, menuMessage, chatMessage, executor, command, revertExecutor, revertCommand);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/rewards/builder/ItemRewardBuilder.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/builder/ItemRewardBuilder.java
@@ -3,7 +3,8 @@ package com.archyx.aureliumskills.rewards.builder;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.rewards.ItemReward;
 import com.archyx.aureliumskills.rewards.Reward;
-import com.archyx.aureliumskills.util.misc.Validate;
+
+import java.util.Objects;
 
 public class ItemRewardBuilder extends MessagedRewardBuilder {
 
@@ -27,7 +28,7 @@ public class ItemRewardBuilder extends MessagedRewardBuilder {
 
     @Override
     public Reward build() {
-        Validate.notNull(itemKey, "You must specify an item key");
+        Objects.requireNonNull(itemKey, "You must specify an item key");
         return new ItemReward(plugin, menuMessage, chatMessage, itemKey, amount);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/rewards/builder/PermissionRewardBuilder.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/builder/PermissionRewardBuilder.java
@@ -3,7 +3,8 @@ package com.archyx.aureliumskills.rewards.builder;
 import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.rewards.PermissionReward;
 import com.archyx.aureliumskills.rewards.Reward;
-import com.archyx.aureliumskills.util.misc.Validate;
+
+import java.util.Objects;
 
 public class PermissionRewardBuilder extends MessagedRewardBuilder {
 
@@ -27,7 +28,7 @@ public class PermissionRewardBuilder extends MessagedRewardBuilder {
 
     @Override
     public Reward build() {
-        Validate.notNull(permission, "You must specify a permission");
+        Objects.requireNonNull(permission, "You must specify a permission");
         return new PermissionReward(plugin, menuMessage, chatMessage, permission, value);
     }
     

--- a/src/main/java/com/archyx/aureliumskills/rewards/builder/StatRewardBuilder.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/builder/StatRewardBuilder.java
@@ -29,6 +29,7 @@ public class StatRewardBuilder extends RewardBuilder {
     @Override
     public Reward build() {
         Validate.notNull(stat, "You must specify a stat");
+        assert (null != stat);
         return new StatReward(plugin, stat, value);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/rewards/builder/StatRewardBuilder.java
+++ b/src/main/java/com/archyx/aureliumskills/rewards/builder/StatRewardBuilder.java
@@ -4,7 +4,8 @@ import com.archyx.aureliumskills.AureliumSkills;
 import com.archyx.aureliumskills.rewards.Reward;
 import com.archyx.aureliumskills.rewards.StatReward;
 import com.archyx.aureliumskills.stats.Stat;
-import com.archyx.aureliumskills.util.misc.Validate;
+
+import java.util.Objects;
 
 public class StatRewardBuilder extends RewardBuilder {
 
@@ -28,8 +29,7 @@ public class StatRewardBuilder extends RewardBuilder {
 
     @Override
     public Reward build() {
-        Validate.notNull(stat, "You must specify a stat");
-        assert (null != stat);
+        Objects.requireNonNull(stat, "You must specify a stat");
         return new StatReward(plugin, stat, value);
     }
 }

--- a/src/main/java/com/archyx/aureliumskills/skills/Skill.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/Skill.java
@@ -4,7 +4,6 @@ import com.archyx.aureliumskills.ability.Ability;
 import com.archyx.aureliumskills.mana.MAbility;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nullable;
 import java.util.Locale;
 import java.util.function.Supplier;
 
@@ -16,7 +15,6 @@ public interface Skill {
 
     String getDisplayName(Locale locale);
 
-    @Nullable
     MAbility getManaAbility();
 
     String name();

--- a/src/main/java/com/archyx/aureliumskills/skills/SkillRegistry.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/SkillRegistry.java
@@ -1,7 +1,5 @@
 package com.archyx.aureliumskills.skills;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
@@ -23,7 +21,6 @@ public class SkillRegistry {
         return skills.values();
     }
 
-    @Nullable
     public Skill getSkill(String key) {
         return this.skills.get(key.toLowerCase(Locale.ROOT));
     }

--- a/src/main/java/com/archyx/aureliumskills/skills/Skills.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/Skills.java
@@ -5,7 +5,6 @@ import com.archyx.aureliumskills.lang.Lang;
 import com.archyx.aureliumskills.lang.SkillMessage;
 import com.archyx.aureliumskills.mana.MAbility;
 import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,16 +59,17 @@ public enum Skills implements Skill {
 
 	@Override
 	public String getDescription(Locale locale) {
-		return Lang.getMessage(SkillMessage.valueOf(this.name() + "_DESC"), locale);
+	    String description = Lang.getMessage(SkillMessage.valueOf(this.name() + "_DESC"), locale);
+		return description;
 	}
 
 	@Override
 	public String getDisplayName(Locale locale) {
-		return Lang.getMessage(SkillMessage.valueOf(this.name().toUpperCase() + "_NAME"), locale);
+	    String displayName = Lang.getMessage(SkillMessage.valueOf(this.name().toUpperCase() + "_NAME"), locale);
+		return displayName;
 	}
 
 	@Override
-	@Nullable
 	public MAbility getManaAbility() {
 		return manaAbility;
 	}

--- a/src/main/java/com/archyx/aureliumskills/skills/agility/AgilityAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/agility/AgilityAbilities.java
@@ -106,6 +106,8 @@ public class AgilityAbilities extends AbilityProvider implements Listener {
                 if (item.getType() == Material.POTION) {
                     if (item.getItemMeta() instanceof PotionMeta) {
                         PotionMeta meta = (PotionMeta) item.getItemMeta();
+                        if (meta == null)
+                            return;
                         PotionData potion = meta.getBasePotionData();
                         double multiplier = 1 + (getValue(Ability.SUGAR_RUSH, playerData) / 100);
                         if (potion.getType() == PotionType.SPEED || potion.getType() == PotionType.JUMP) {

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
@@ -211,12 +211,13 @@ public class AlchemyAbilities extends AbilityProvider implements Listener {
         if (blockDisabled(Ability.ALCHEMIST)) return;
         if (event.isCancelled()) return;
         ItemStack item = event.getPotion().getItem();
-        if (item.getItemMeta() instanceof PotionMeta && item.getItemMeta() != null) {
-            PotionMeta meta = (PotionMeta) item.getItemMeta();
-            if (meta == null)
-                return;
-            PotionData potionData = meta.getBasePotionData();
-            if (meta.hasCustomEffects() && OptionL.getBoolean(Option.ALCHEMY_IGNORE_CUSTOM_POTIONS)) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null)
+            return;
+        if (meta instanceof PotionMeta) {
+            PotionMeta potionMeta = (PotionMeta) meta;
+            PotionData potionData = potionMeta.getBasePotionData();
+            if (potionMeta.hasCustomEffects() && OptionL.getBoolean(Option.ALCHEMY_IGNORE_CUSTOM_POTIONS)) return;
             // Get potion duration bonus from Alchemist ability
             int durationBonus = 0;
             if (!NBTAPIUser.isNBTDisabled(plugin)) {

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
@@ -136,9 +136,11 @@ public class AlchemyAbilities extends AbilityProvider implements Listener {
                     // Add lore
                     if (plugin.getAbilityManager().getOptionAsBooleanElseTrue(Ability.ALCHEMIST, "add_item_lore")) {
                         List<String> lore = new ArrayList<>();
-                        lore.add(TextUtil.replace(Lang.getMessage(AbilityMessage.ALCHEMIST_LORE, locale)
+                        String t = TextUtil.replace(Lang.getMessage(AbilityMessage.ALCHEMIST_LORE, locale)
                                 , "{duration}", PotionUtil.formatDuration(durationBonus)
-                                , "{value}", NumberUtil.format1((multiplier - 1) * 100)));
+                                , "{value}", NumberUtil.format1((multiplier - 1) * 100));
+                        assert (null != t);
+                        lore.add(t);
                         meta.setLore(lore);
                         item.setItemMeta(meta);
                     }
@@ -211,6 +213,8 @@ public class AlchemyAbilities extends AbilityProvider implements Listener {
         ItemStack item = event.getPotion().getItem();
         if (item.getItemMeta() instanceof PotionMeta && item.getItemMeta() != null) {
             PotionMeta meta = (PotionMeta) item.getItemMeta();
+            if (meta == null)
+                return;
             PotionData potionData = meta.getBasePotionData();
             if (meta.hasCustomEffects() && OptionL.getBoolean(Option.ALCHEMY_IGNORE_CUSTOM_POTIONS)) return;
             // Get potion duration bonus from Alchemist ability

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyAbilities.java
@@ -136,11 +136,9 @@ public class AlchemyAbilities extends AbilityProvider implements Listener {
                     // Add lore
                     if (plugin.getAbilityManager().getOptionAsBooleanElseTrue(Ability.ALCHEMIST, "add_item_lore")) {
                         List<String> lore = new ArrayList<>();
-                        String t = TextUtil.replace(Lang.getMessage(AbilityMessage.ALCHEMIST_LORE, locale)
+                        lore.add(TextUtil.replace(Lang.getMessage(AbilityMessage.ALCHEMIST_LORE, locale)
                                 , "{duration}", PotionUtil.formatDuration(durationBonus)
-                                , "{value}", NumberUtil.format1((multiplier - 1) * 100));
-                        assert (null != t);
-                        lore.add(t);
+                                , "{value}", NumberUtil.format1((multiplier - 1) * 100)));
                         meta.setLore(lore);
                         item.setItemMeta(meta);
                     }

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemyLeveler.java
@@ -63,7 +63,9 @@ public class AlchemyLeveler extends SkillLeveler implements Listener {
 						if (player != null) {
 							if (blockXpGainLocation(event.getBlock().getLocation(), player)) return;
 							if (blockXpGainPlayer(player)) return;
-							addAlchemyXp(player, event.getContents().getIngredient().getType());
+							ItemStack item = event.getContents().getIngredient();
+							if (item != null)
+								addAlchemyXp(player, item.getType());
 						}
 					}
 				}
@@ -146,7 +148,10 @@ public class AlchemyLeveler extends SkillLeveler implements Listener {
 			if (OptionL.isEnabled(Skills.ALCHEMY)) {
 				if (event.getInventory().getHolder() != null) {
 					if (event.getInventory().getLocation() != null) {
-						Block block = event.getInventory().getLocation().getBlock();
+						Location location = event.getInventory().getLocation();
+						if (location == null)
+							return;
+						Block block = location.getBlock();
 						if (!block.hasMetadata("skillsBrewingStandOwner")) {
 							block.setMetadata("skillsBrewingStandOwner", new FixedMetadataValue(plugin, event.getPlayer().getUniqueId()));
 						}

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemySource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/AlchemySource.java
@@ -39,9 +39,11 @@ public enum AlchemySource implements Source {
         ItemStack baseItem = ItemUtils.parseItem(material);
         if (baseItem != null && baseItem.getItemMeta() instanceof PotionMeta) {
             PotionMeta meta = (PotionMeta) baseItem.getItemMeta();
-            meta.setBasePotionData(new PotionData(potionType));
-            meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
-            baseItem.setItemMeta(meta);
+            if (meta != null) {
+                meta.setBasePotionData(new PotionData(potionType));
+                meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+                baseItem.setItemMeta(meta);
+            }
         }
         return baseItem;
     }

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/BrewingStandData.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/BrewingStandData.java
@@ -4,6 +4,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class BrewingStandData {
 
@@ -16,7 +17,7 @@ public class BrewingStandData {
     }
 
     public boolean isSlotBrewed(int slot) {
-        return potionSlots.getOrDefault(slot, false);
+        return Objects.requireNonNullElse(potionSlots.get(slot), false);
     }
 
     public void setSlotBrewed(int slot, boolean isSlotBrewed) {

--- a/src/main/java/com/archyx/aureliumskills/skills/alchemy/BrewingStandData.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/alchemy/BrewingStandData.java
@@ -4,7 +4,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 public class BrewingStandData {
 
@@ -17,7 +16,10 @@ public class BrewingStandData {
     }
 
     public boolean isSlotBrewed(int slot) {
-        return Objects.requireNonNullElse(potionSlots.get(slot), false);
+        Boolean isBrewed = potionSlots.get(slot);
+        if (isBrewed == null)
+            throw new IndexOutOfBoundsException();
+        return isBrewed;
     }
 
     public void setSlotBrewed(int slot, boolean isSlotBrewed) {

--- a/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
@@ -111,7 +111,10 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
                     Arrow arrow = (Arrow) event.getDamager();
                     if (arrow.getShooter() instanceof Player) {
                         Player player = (Player) arrow.getShooter();
-                        if (player != null && blockAbility(player)) return;
+                        if (player == null)
+                            return;
+                        if (blockAbility(player))
+                            return;
                         // Applies abilities
                         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
                         if (playerData == null) return;
@@ -122,7 +125,7 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
                                 stun(playerData, entity);
                             }
                         }
-                        if (player != null && options.isEnabled(Ability.PIERCING)) {
+                        if (options.isEnabled(Ability.PIERCING)) {
                             piercing(event, playerData, player, arrow);
                         }
                     }

--- a/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryAbilities.java
@@ -111,7 +111,7 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
                     Arrow arrow = (Arrow) event.getDamager();
                     if (arrow.getShooter() instanceof Player) {
                         Player player = (Player) arrow.getShooter();
-                        if (blockAbility(player)) return;
+                        if (player != null && blockAbility(player)) return;
                         // Applies abilities
                         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
                         if (playerData == null) return;
@@ -122,7 +122,7 @@ public class ArcheryAbilities extends AbilityProvider implements Listener {
                                 stun(playerData, entity);
                             }
                         }
-                        if (options.isEnabled(Ability.PIERCING)) {
+                        if (player != null && options.isEnabled(Ability.PIERCING)) {
                             piercing(event, playerData, player, arrow);
                         }
                     }

--- a/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/archery/ArcheryLeveler.java
@@ -28,7 +28,7 @@ public class ArcheryLeveler extends SkillLeveler implements Listener {
 			if (e.getKiller() != null) {
 				if (e.getLastDamageCause() instanceof EntityDamageByEntityEvent) {
 					EntityDamageByEntityEvent ee = (EntityDamageByEntityEvent) e.getLastDamageCause();
-					if (ee.getDamager() instanceof Projectile) {
+					if (ee != null && ee.getDamager() instanceof Projectile) {
 						EntityType type = e.getType();
 						Player p = e.getKiller();
 						Skill skill = Skills.ARCHERY;
@@ -39,6 +39,8 @@ public class ArcheryLeveler extends SkillLeveler implements Listener {
 								return;
 							}
 						}
+						if (p == null)
+							return;
 						if (blockXpGainLocation(e.getLocation(), p)) return;
 						if (blockXpGainPlayer(p)) return;
 						if (e.equals(p)) return;
@@ -82,7 +84,7 @@ public class ArcheryLeveler extends SkillLeveler implements Listener {
 				}
 				if (projectile.getShooter() instanceof Player) {
 					Player player = (Player) projectile.getShooter();
-					if (event.getEntity() instanceof LivingEntity) {
+					if (player != null && event.getEntity() instanceof LivingEntity) {
 						LivingEntity entity = (LivingEntity) event.getEntity();
 						if (blockXpGainLocation(entity.getLocation(), player)) return;
 						EntityType type = entity.getType();

--- a/src/main/java/com/archyx/aureliumskills/skills/archery/ArcherySource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/archery/ArcherySource.java
@@ -101,15 +101,17 @@ public enum ArcherySource implements Source {
 
     @Override
     public String toString() {
-        return configName != null ? configName.toUpperCase(Locale.ROOT) : name();
+        String name = configName;
+        return name != null ? name.toUpperCase(Locale.ROOT) : name();
     }
 
     @Override
     public String getPath() {
-        if (configName == null) {
+        String name = configName;
+        if (name == null) {
             return getSkill().toString().toLowerCase(Locale.ROOT) + "." + toString().toLowerCase(Locale.ROOT);
         } else {
-            return getSkill().toString().toLowerCase(Locale.ROOT) + "." + configName.toLowerCase(Locale.ROOT);
+            return getSkill().toString().toLowerCase(Locale.ROOT) + "." + name.toLowerCase(Locale.ROOT);
         }
     }
 

--- a/src/main/java/com/archyx/aureliumskills/skills/defense/DefenseAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/defense/DefenseAbilities.java
@@ -13,7 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -86,8 +86,8 @@ public class DefenseAbilities extends AbilityProvider implements Listener {
 
     public void noDebuffFire(PlayerData playerData, Player player, LivingEntity entity) {
         if (entity.getEquipment() != null) {
-            ItemStack item = entity.getEquipment().getItemInMainHand();
-            if (item != null && item.getEnchantmentLevel(Enchantment.FIRE_ASPECT) > 0) {
+            EntityEquipment equipment = entity.getEquipment();
+            if (equipment != null && equipment.getItemInMainHand().getEnchantmentLevel(Enchantment.FIRE_ASPECT) > 0) {
                 double chance = getValue(Ability.NO_DEBUFF, playerData) / 100;
                 if (r.nextDouble() < chance) {
                     new BukkitRunnable() {

--- a/src/main/java/com/archyx/aureliumskills/skills/defense/DefenseLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/defense/DefenseLeveler.java
@@ -14,6 +14,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.projectiles.ProjectileSource;
 
 public class DefenseLeveler extends SkillLeveler implements Listener {
 
@@ -59,8 +60,9 @@ public class DefenseLeveler extends SkillLeveler implements Listener {
 							// Make sure player didn't cause own damage
 							if (event.getDamager() instanceof Projectile) {
 								Projectile projectile = (Projectile) event.getDamager();
-								if (projectile.getShooter() instanceof Player) {
-									if (projectile.getShooter().equals(player)) return;
+								ProjectileSource shooter = projectile.getShooter();
+								if (shooter != null && projectile.getShooter() instanceof Player) {
+									if (shooter.equals(player)) return;
 								}
 							}
 							if (originalDamage * getXp(DefenseSource.MOB_DAMAGE) <= OptionL.getDouble(Option.DEFENSE_MAX)) {

--- a/src/main/java/com/archyx/aureliumskills/skills/enchanting/EnchantingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/enchanting/EnchantingAbilities.java
@@ -59,7 +59,7 @@ public class EnchantingAbilities extends AbilityProvider implements Listener {
         LivingEntity entity = event.getEntity();
         if (entity.getKiller() != null) {
             Player player = entity.getKiller();
-            if (blockAbility(player)) return;
+            if (player != null && blockAbility(player)) return;
             PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
             if (playerData != null) {
                 if (playerData.getAbilityLevel(Ability.XP_WARRIOR) > 0 && event.getDroppedExp() > 0) {

--- a/src/main/java/com/archyx/aureliumskills/skills/enchanting/EnchantingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/enchanting/EnchantingAbilities.java
@@ -59,7 +59,10 @@ public class EnchantingAbilities extends AbilityProvider implements Listener {
         LivingEntity entity = event.getEntity();
         if (entity.getKiller() != null) {
             Player player = entity.getKiller();
-            if (player != null && blockAbility(player)) return;
+            if (player == null)
+                return;
+            if (blockAbility(player))
+                return;
             PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
             if (playerData != null) {
                 if (playerData.getAbilityLevel(Ability.XP_WARRIOR) > 0 && event.getDroppedExp() > 0) {

--- a/src/main/java/com/archyx/aureliumskills/skills/excavation/ExcavationSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/excavation/ExcavationSource.java
@@ -7,7 +7,6 @@ import com.archyx.aureliumskills.source.Source;
 import com.archyx.aureliumskills.util.item.ItemUtils;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 public enum ExcavationSource implements Source, BlockSource {
 
@@ -52,7 +51,6 @@ public enum ExcavationSource implements Source, BlockSource {
         this.allowBothIfLegacy = allowBothIfLegacy;
     }
 
-    @Nullable
     @Override
     public String getLegacyMaterial() {
         return legacyMaterial;
@@ -73,7 +71,6 @@ public enum ExcavationSource implements Source, BlockSource {
         return Skills.EXCAVATION;
     }
 
-    @Nullable
     public static ExcavationSource getSource(Block block) {
         for (ExcavationSource source : values()) {
             if (source.isMatch(block)) {

--- a/src/main/java/com/archyx/aureliumskills/skills/farming/FarmingSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/farming/FarmingSource.java
@@ -7,7 +7,6 @@ import com.archyx.aureliumskills.util.block.BlockUtil;
 import com.archyx.aureliumskills.util.item.ItemUtils;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 public enum FarmingSource implements Source {
 
@@ -104,7 +103,6 @@ public enum FarmingSource implements Source {
         return Skills.FARMING;
     }
 
-    @Nullable
     public static FarmingSource getSource(Block block) {
         for (FarmingSource source : values()) {
             if (source.isMatch(block)) {

--- a/src/main/java/com/archyx/aureliumskills/skills/fighting/FightingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fighting/FightingAbilities.java
@@ -98,8 +98,14 @@ public class FightingAbilities extends AbilityProvider implements Listener {
     public void bleed(EntityDamageByEntityEvent event, PlayerData playerData, LivingEntity entity) {
         if (r.nextDouble() < (getValue(Ability.BLEED, playerData) / 100)) {
             if (event.getFinalDamage() < entity.getHealth()) {
+                String key;
+                OptionValue optionValue;
                 if (!entity.hasMetadata("AureliumSkills-BleedTicks")) {
-                    int baseTicks = plugin.getAbilityManager().getOption(Ability.BLEED, "base_ticks").asInt();
+                    key = "base_ticks";
+                    optionValue = plugin.getAbilityManager().getOption(Ability.BLEED, key);
+                    if (optionValue == null)
+                        throw new IllegalStateException("Invalid ability manager option index key: " + key);
+                    int baseTicks = optionValue.asInt();
                     entity.setMetadata("AureliumSkills-BleedTicks", new FixedMetadataValue(plugin, baseTicks));
                     // Send messages
                     if (plugin.getAbilityManager().getOptionAsBooleanElseTrue(Ability.BLEED, "enable_enemy_message")) {
@@ -120,8 +126,16 @@ public class FightingAbilities extends AbilityProvider implements Listener {
                     scheduleBleedTicks(entity, playerData);
                 } else {
                     int currentTicks = entity.getMetadata("AureliumSkills-BleedTicks").get(0).asInt();
-                    int addedTicks = plugin.getAbilityManager().getOption(Ability.BLEED, "added_ticks").asInt();
-                    int maxTicks = plugin.getAbilityManager().getOption(Ability.BLEED, "max_ticks").asInt();
+                    key = "added_ticks";
+                    optionValue = plugin.getAbilityManager().getOption(Ability.BLEED, key);
+                    if (optionValue == null)
+                        throw new IllegalStateException("Invalid ability manager option index key: " + key);
+                    int addedTicks = optionValue.asInt();
+                    key = "max_ticks";
+                    optionValue = plugin.getAbilityManager().getOption(Ability.BLEED, key);
+                    if (optionValue == null)
+                        throw new IllegalStateException("Invalid ability manager option index key: " + key);
+                    int maxTicks = optionValue.asInt();
                     int resultingTicks = currentTicks + addedTicks;
                     if (resultingTicks <= maxTicks) { // Check that resulting bleed ticks does not exceed maximum
                         entity.setMetadata("AureliumSkills-BleedTicks", new FixedMetadataValue(plugin, resultingTicks));
@@ -132,6 +146,10 @@ public class FightingAbilities extends AbilityProvider implements Listener {
     }
 
     private void scheduleBleedTicks(LivingEntity entity, PlayerData playerData) {
+        String key = "tick_period";
+        OptionValue optionValue = plugin.getAbilityManager().getOption(Ability.BLEED, key);
+        if (optionValue == null)
+            throw new IllegalStateException("Invalid ability manager option index key: " + key);
         // Schedules bleed ticks
         new BukkitRunnable() {
             @Override
@@ -169,7 +187,7 @@ public class FightingAbilities extends AbilityProvider implements Listener {
                 }
                 cancel();
             }
-        }.runTaskTimer(plugin, 40L, plugin.getAbilityManager().getOption(Ability.BLEED, "tick_period").asInt());
+        }.runTaskTimer(plugin, 40L, optionValue.asInt());
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/archyx/aureliumskills/skills/fighting/FightingLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fighting/FightingLeveler.java
@@ -32,7 +32,7 @@ public class FightingLeveler extends SkillLeveler implements Listener {
 			if (e.getKiller() != null) {
 				if (e.getLastDamageCause() instanceof EntityDamageByEntityEvent) {
 					EntityDamageByEntityEvent ee = (EntityDamageByEntityEvent) e.getLastDamageCause();
-					if (ee.getDamager() instanceof Player) {
+					if (ee != null && ee.getDamager() instanceof Player) {
 						EntityType type = e.getType();
 						Player p = (Player) ee.getDamager();
 						if (blockXpGainLocation(e.getLocation(), p)) return;

--- a/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingAbilities.java
@@ -8,6 +8,7 @@ import com.archyx.aureliumskills.api.event.PlayerLootDropEvent;
 import com.archyx.aureliumskills.data.PlayerData;
 import com.archyx.aureliumskills.skills.Skills;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -38,7 +39,10 @@ public class FishingAbilities extends AbilityProvider implements Listener {
 				PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
 				if (playerData != null) {
 					if (r.nextDouble() < (getValue(Ability.LUCKY_CATCH, playerData) / 100)) {
-						Item item = (Item) event.getCaught();
+						Entity caught = event.getCaught();
+						if (caught == null)
+							return;
+						Item item = (Item) caught;
 						ItemStack drop = item.getItemStack();
 						if (drop.getMaxStackSize() > 1) {
 							drop.setAmount(drop.getAmount() * 2);
@@ -63,13 +67,16 @@ public class FishingAbilities extends AbilityProvider implements Listener {
 				if (playerData != null) {
 					Player player = event.getPlayer();
 					if (blockAbility(player)) return;
-					Vector vector = player.getLocation().toVector().subtract(event.getCaught().getLocation().toVector());
+					Entity caught = event.getCaught();
+					if (caught == null)
+						return;
+					Vector vector = player.getLocation().toVector().subtract(caught.getLocation().toVector());
 					Vector result = vector.multiply(0.004 + (getValue(Ability.GRAPPLER, playerData) / 25000));
 
 					if (isUnsafeVelocity(result)) { // Prevent excessive velocity warnings
 						return;
 					}
-					event.getCaught().setVelocity(result);
+					caught.setVelocity(result);
 				}
 			}
 		}

--- a/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingLeveler.java
@@ -7,6 +7,8 @@ import com.archyx.aureliumskills.configuration.OptionL;
 import com.archyx.aureliumskills.leveler.Leveler;
 import com.archyx.aureliumskills.leveler.SkillLeveler;
 import com.archyx.aureliumskills.skills.Skills;
+
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -35,11 +37,14 @@ public class FishingLeveler extends SkillLeveler implements Listener {
 				Player player = event.getPlayer();
 				if (blockXpGain(player)) return;
 				if (event.getCaught() instanceof Item) {
-					ItemStack item = ((Item) event.getCaught()).getItemStack();
-					Leveler leveler = plugin.getLeveler();
-					FishingSource source = FishingSource.valueOf(item);
-					if (source != null) {
-						leveler.addXp(player, Skills.FISHING, getXp(player, source));
+					Entity caught = event.getCaught();
+					if (caught != null) {
+						ItemStack item = ((Item) caught).getItemStack();
+						Leveler leveler = plugin.getLeveler();
+						FishingSource source = FishingSource.valueOf(item);
+						if (source != null) {
+							leveler.addXp(player, Skills.FISHING, getXp(player, source));
+						}
 					}
 				}
 			}

--- a/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingLootHandler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingLootHandler.java
@@ -9,13 +9,13 @@ import com.archyx.aureliumskills.loot.handler.LootHandler;
 import com.archyx.aureliumskills.skills.Skills;
 import com.archyx.aureliumskills.source.Source;
 import com.archyx.aureliumskills.support.WorldGuardFlags;
+import com.archyx.aureliumskills.support.WorldGuardSupport;
 import com.archyx.aureliumskills.util.version.VersionUtils;
 import com.archyx.lootmanager.loot.Loot;
 import com.archyx.lootmanager.loot.LootPool;
 import com.archyx.lootmanager.loot.LootTable;
 import com.archyx.lootmanager.loot.type.CommandLoot;
 import com.archyx.lootmanager.loot.type.ItemLoot;
-
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
@@ -43,12 +43,13 @@ public class FishingLootHandler extends LootHandler implements Listener {
         if (plugin.getWorldManager().isInBlockedWorld(player.getLocation())) {
             return;
         }
-        if (plugin.isWorldGuardEnabled()) {
-            if (plugin.getWorldGuardSupport().isInBlockedRegion(player.getLocation())) {
+        WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+        if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+            if (worldGuardSupport.isInBlockedRegion(player.getLocation())) {
                 return;
             }
             // Check if blocked by flags
-            else if (plugin.getWorldGuardSupport().blockedByFlag(player.getLocation(), player, WorldGuardFlags.FlagKey.CUSTOM_LOOT)) {
+            else if (worldGuardSupport.blockedByFlag(player.getLocation(), player, WorldGuardFlags.FlagKey.CUSTOM_LOOT)) {
                 return;
             }
         }

--- a/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingLootHandler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingLootHandler.java
@@ -15,6 +15,8 @@ import com.archyx.lootmanager.loot.LootPool;
 import com.archyx.lootmanager.loot.LootTable;
 import com.archyx.lootmanager.loot.type.CommandLoot;
 import com.archyx.lootmanager.loot.type.ItemLoot;
+
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -57,10 +59,13 @@ public class FishingLootHandler extends LootHandler implements Listener {
 
         PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
         if (playerData == null) return;
-
-        ItemStack originalItem = ((Item) event.getCaught()).getItemStack();
+        Entity caught = event.getCaught();
+        if (caught == null)
+            return;
+        ItemStack originalItem = ((Item)caught).getItemStack();
         FishingSource originalSource = FishingSource.valueOf(originalItem);
-
+        if (originalSource == null)
+            return;
         LootTable table = plugin.getLootTableManager().getLootTable(Skills.FISHING);
         if (table == null) return;
         for (LootPool pool : table.getPools()) {

--- a/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/fishing/FishingSource.java
@@ -7,7 +7,6 @@ import com.archyx.aureliumskills.util.item.ItemUtils;
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -39,7 +38,6 @@ public enum FishingSource implements Source {
     }
 
     @SuppressWarnings("deprecation")
-    @Nullable
     public static FishingSource valueOf(ItemStack item) {
         Material mat = item.getType();
         if (XMaterial.isNewVersion()) {

--- a/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingAbilities.java
@@ -81,7 +81,7 @@ public class ForagingAbilities extends AbilityProvider implements Listener {
 				if (event.getPlayer().getLastDamageCause() instanceof EntityDamageByEntityEvent) {
 					EntityDamageByEntityEvent e = (EntityDamageByEntityEvent) event.getPlayer().getLastDamageCause();
 					//If last damage was from player
-					if (e.getDamager() instanceof Player) {
+					if (e != null && e.getDamager() instanceof Player) {
 						Player player = (Player) e.getDamager();
 						if (blockAbility(player)) return;
 						//If damage was an attack

--- a/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingSource.java
@@ -135,15 +135,17 @@ public enum ForagingSource implements Source {
                 }
             }
         } else { // Legacy block handling
-            if (getLegacyData() == null) { // No data value
-                if (getLegacyMaterial().equalsIgnoreCase(materialName)) {
-                    matched = true;
+            String legacyMaterial = getLegacyMaterial();
+            if (legacyMaterial != null)
+                if (getLegacyData() == null) { // No data value
+                    if (legacyMaterial.equalsIgnoreCase(materialName)) {
+                        matched = true;
+                    }
+                } else { // With data value
+                    if (legacyMaterial.equalsIgnoreCase(materialName) && byteArrayContains(legacyData, blockState.getRawData())) {
+                        matched = true;
+                    }
                 }
-            } else { // With data value
-                if (getLegacyMaterial().equalsIgnoreCase(materialName) && byteArrayContains(legacyData, blockState.getRawData())) {
-                    matched = true;
-                }
-            }
         }
         return matched;
     }

--- a/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingSource.java
@@ -8,7 +8,6 @@ import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 public enum ForagingSource implements Source {
 
@@ -40,7 +39,7 @@ public enum ForagingSource implements Source {
 
     private String[] alternateMaterials;
     private String legacyMaterial;
-    private byte[] legacyData;
+    private byte [] legacyData = {};
     private boolean requiresBlockBelow;
     private boolean isTrunk;
     private boolean isLeaf;
@@ -71,32 +70,31 @@ public enum ForagingSource implements Source {
         this.isTrunk = isTrunk;
     }
 
-    ForagingSource(String legacyMaterial, byte[] legacyData) {
+    ForagingSource(String legacyMaterial, byte [] legacyData) {
         this(legacyMaterial);
         this.legacyData = legacyData;
     }
 
-    ForagingSource(String legacyMaterial, byte[] legacyData, boolean isLeaf) {
+    ForagingSource(String legacyMaterial, byte [] legacyData, boolean isLeaf) {
         this(legacyMaterial, legacyData);
         this.isLeaf = isLeaf;
     }
 
-    ForagingSource(String legacyMaterial, byte[] legacyData, String... alternateMaterials) {
+    ForagingSource(String legacyMaterial, byte [] legacyData, String... alternateMaterials) {
         this(legacyMaterial, legacyData);
         this.alternateMaterials = alternateMaterials;
     }
 
-    ForagingSource(String legacyMaterial, byte[] legacyData, boolean isTrunk, String... alternateMaterials) {
+    ForagingSource(String legacyMaterial, byte [] legacyData, boolean isTrunk, String... alternateMaterials) {
         this(legacyMaterial, legacyData, alternateMaterials);
         this.isTrunk = isTrunk;
     }
 
-    @Nullable
     public String getLegacyMaterial() {
         return legacyMaterial;
     }
 
-    public byte[] getLegacyData() {
+    public byte [] getLegacyData() {
         return legacyData;
     }
 
@@ -104,7 +102,6 @@ public enum ForagingSource implements Source {
         return requiresBlockBelow;
     }
 
-    @Nullable
     public String[] getAlternateMaterials() {
         return alternateMaterials;
     }
@@ -121,7 +118,8 @@ public enum ForagingSource implements Source {
     public boolean isMatch(BlockState blockState) {
         boolean matched = false;
         String materialName = blockState.getType().toString();
-        if (XMaterial.isNewVersion() || getLegacyMaterial() == null) { // Standard block handling
+        String legacyMaterial = getLegacyMaterial();
+        if (XMaterial.isNewVersion() || legacyMaterial == null) { // Standard block handling
             if (toString().equalsIgnoreCase(materialName)) {
                 matched = true;
             } else if (getAlternateMaterials() != null) {
@@ -135,17 +133,15 @@ public enum ForagingSource implements Source {
                 }
             }
         } else { // Legacy block handling
-            String legacyMaterial = getLegacyMaterial();
-            if (legacyMaterial != null)
-                if (getLegacyData() == null) { // No data value
-                    if (legacyMaterial.equalsIgnoreCase(materialName)) {
-                        matched = true;
-                    }
-                } else { // With data value
-                    if (legacyMaterial.equalsIgnoreCase(materialName) && byteArrayContains(legacyData, blockState.getRawData())) {
-                        matched = true;
-                    }
+            if (getLegacyData().length == 0) { // No data value
+                if (legacyMaterial.equalsIgnoreCase(materialName)) {
+                    matched = true;
                 }
+            } else { // With data value
+                if (legacyMaterial.equalsIgnoreCase(materialName) && byteArrayContains(legacyData, blockState.getRawData())) {
+                    matched = true;
+                }
+            }
         }
         return matched;
     }
@@ -154,7 +150,7 @@ public enum ForagingSource implements Source {
         return isMatch(block.getState());
     }
 
-    private boolean byteArrayContains(byte[] array, byte input) {
+    private boolean byteArrayContains(byte [] array, byte input) {
         for (byte b : array) {
             if (b == input) return true;
         }
@@ -166,7 +162,6 @@ public enum ForagingSource implements Source {
         return Skills.FORAGING;
     }
 
-    @Nullable
     public static ForagingSource getSource(BlockState blockState) {
         for (ForagingSource source : values()) {
             if (source.isMatch(blockState)) {
@@ -176,7 +171,6 @@ public enum ForagingSource implements Source {
         return null;
     }
 
-    @Nullable
     public static ForagingSource getSource(Block block) {
         return getSource(block.getState());
     }

--- a/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/foraging/ForagingSource.java
@@ -39,7 +39,7 @@ public enum ForagingSource implements Source {
 
     private String[] alternateMaterials;
     private String legacyMaterial;
-    private byte [] legacyData = {};
+    private byte[] legacyData = {};
     private boolean requiresBlockBelow;
     private boolean isTrunk;
     private boolean isLeaf;
@@ -70,22 +70,22 @@ public enum ForagingSource implements Source {
         this.isTrunk = isTrunk;
     }
 
-    ForagingSource(String legacyMaterial, byte [] legacyData) {
+    ForagingSource(String legacyMaterial, byte[] legacyData) {
         this(legacyMaterial);
         this.legacyData = legacyData;
     }
 
-    ForagingSource(String legacyMaterial, byte [] legacyData, boolean isLeaf) {
+    ForagingSource(String legacyMaterial, byte[] legacyData, boolean isLeaf) {
         this(legacyMaterial, legacyData);
         this.isLeaf = isLeaf;
     }
 
-    ForagingSource(String legacyMaterial, byte [] legacyData, String... alternateMaterials) {
+    ForagingSource(String legacyMaterial, byte[] legacyData, String... alternateMaterials) {
         this(legacyMaterial, legacyData);
         this.alternateMaterials = alternateMaterials;
     }
 
-    ForagingSource(String legacyMaterial, byte [] legacyData, boolean isTrunk, String... alternateMaterials) {
+    ForagingSource(String legacyMaterial, byte[] legacyData, boolean isTrunk, String... alternateMaterials) {
         this(legacyMaterial, legacyData, alternateMaterials);
         this.isTrunk = isTrunk;
     }
@@ -94,7 +94,7 @@ public enum ForagingSource implements Source {
         return legacyMaterial;
     }
 
-    public byte [] getLegacyData() {
+    public byte[] getLegacyData() {
         return legacyData;
     }
 
@@ -150,7 +150,7 @@ public enum ForagingSource implements Source {
         return isMatch(block.getState());
     }
 
-    private boolean byteArrayContains(byte [] array, byte input) {
+    private boolean byteArrayContains(byte[] array, byte input) {
         for (byte b : array) {
             if (b == input) return true;
         }

--- a/src/main/java/com/archyx/aureliumskills/skills/forging/ForgingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/forging/ForgingAbilities.java
@@ -55,7 +55,7 @@ public class ForgingAbilities extends AbilityProvider implements Listener {
             if (click != ClickType.LEFT && click != ClickType.RIGHT && ItemUtils.isInventoryFull(player)) return;
             if (event.getResult() != Event.Result.ALLOW) return; // Make sure the click was successful
             if (player.getItemOnCursor().getType() != Material.AIR) return; // Make sure cursor is empty
-            if (event.getClickedInventory().getType() == InventoryType.GRINDSTONE) {
+            if (inventory.getType() == InventoryType.GRINDSTONE) {
                 if (event.getSlotType() == InventoryType.SlotType.RESULT) {
                     PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
                     if (playerData == null) return;

--- a/src/main/java/com/archyx/aureliumskills/skills/forging/ForgingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/forging/ForgingAbilities.java
@@ -28,7 +28,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -227,7 +226,6 @@ public class ForgingAbilities extends AbilityProvider implements Listener {
         }
     }
 
-    @Nullable
     private XMaterial getRawMaterial(Material material) {
         String name = material.name();
         if (name.startsWith("DIAMOND_")) {
@@ -264,7 +262,6 @@ public class ForgingAbilities extends AbilityProvider implements Listener {
         return null;
     }
 
-    @Nullable
     private Player getHighestPlayer(List<HumanEntity> viewers) {
         int highestLevel = 0;
         Player highestPlayer = null;

--- a/src/main/java/com/archyx/aureliumskills/skills/forging/ForgingLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/forging/ForgingLeveler.java
@@ -8,6 +8,8 @@ import com.archyx.aureliumskills.leveler.SkillLeveler;
 import com.archyx.aureliumskills.skills.Skill;
 import com.archyx.aureliumskills.skills.Skills;
 import com.archyx.aureliumskills.util.item.ItemUtils;
+
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -62,8 +64,9 @@ public class ForgingLeveler extends SkillLeveler implements Listener {
 					if (event.getSlot() == 2) {
 						ItemStack addedItem = inventory.getItem(1);
 						ItemStack baseItem = inventory.getItem(0);
-						if (inventory.getLocation() != null) {
-							if (blockXpGainLocation(inventory.getLocation(), player)) return;
+						Location location = inventory.getLocation();
+						if (location != null) {
+							if (blockXpGainLocation(location, player)) return;
 						} else {
 							if (blockXpGainLocation(event.getWhoClicked().getLocation(), player)) return;
 						}
@@ -87,8 +90,9 @@ public class ForgingLeveler extends SkillLeveler implements Listener {
 					}
 				} else if (inventory.getType().toString().equals("GRINDSTONE")) {
 					if (event.getSlotType() != InventoryType.SlotType.RESULT) return;
-					if (inventory.getLocation() != null) {
-						if (blockXpGainLocation(inventory.getLocation(), player)) return;
+					Location location = inventory.getLocation();
+					if (location != null) {
+						if (blockXpGainLocation(location, player)) return;
 					} else {
 						if (blockXpGainLocation(event.getWhoClicked().getLocation(), player)) return;
 					}
@@ -115,11 +119,12 @@ public class ForgingLeveler extends SkillLeveler implements Listener {
 			}
 			if (item.getItemMeta() instanceof EnchantmentStorageMeta) {
 				EnchantmentStorageMeta esm = (EnchantmentStorageMeta) item.getItemMeta();
-				for (Map.Entry<Enchantment, Integer> entry : esm.getStoredEnchants().entrySet()) {
-					if (isDisenchantable(entry.getKey())) {
-						totalLevel += entry.getValue();
+				if (esm != null)
+					for (Map.Entry<Enchantment, Integer> entry : esm.getStoredEnchants().entrySet()) {
+						if (isDisenchantable(entry.getKey())) {
+							totalLevel += entry.getValue();
+						}
 					}
-				}
 			}
 		}
 		return totalLevel;

--- a/src/main/java/com/archyx/aureliumskills/skills/healing/HealingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/healing/HealingAbilities.java
@@ -72,6 +72,8 @@ public class HealingAbilities extends AbilityProvider implements Listener {
         if (hostile) {
             if (entity.getKiller() == null) return;
             Player player = entity.getKiller();
+            if (player == null)
+                return;
             if (player.equals(entity)) return;
             if (blockAbility(player)) return;
             PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);

--- a/src/main/java/com/archyx/aureliumskills/skills/healing/HealingAbilities.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/healing/HealingAbilities.java
@@ -153,6 +153,8 @@ public class HealingAbilities extends AbilityProvider implements Listener {
         if (VersionUtils.isAtLeastVersion(14, 4)) {
             return player.getAbsorptionAmount();
         } else {
+            Class<?> entityLivingClass = this.entityLivingClass;
+            Class<?> craftPlayerClass = this.craftPlayerClass;
             if (entityLivingClass == null) {
                 entityLivingClass = ReflectionUtils.getNMSClass("EntityLiving");
             }

--- a/src/main/java/com/archyx/aureliumskills/skills/healing/HealingLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/healing/HealingLeveler.java
@@ -51,6 +51,8 @@ public class HealingLeveler extends SkillLeveler implements Listener {
 			if (event.getItem().getType().equals(Material.POTION)) {
 				if (event.getItem().getItemMeta() instanceof PotionMeta) {
 					PotionMeta meta = (PotionMeta) event.getItem().getItemMeta();
+					if (meta == null)
+						return;
 					PotionData data = meta.getBasePotionData();
 					if (OptionL.getBoolean(Option.HEALING_EXCLUDE_NEGATIVE_POTIONS) && PotionUtil.isNegativePotion(data.getType())) {
 						return;
@@ -108,6 +110,8 @@ public class HealingLeveler extends SkillLeveler implements Listener {
 					if (event.getPotion().getItem().getItemMeta() instanceof PotionMeta) {
 						Player player = (Player) event.getEntity().getShooter();
 						PotionMeta meta = (PotionMeta) event.getPotion().getItem().getItemMeta();
+						if (player == null || meta == null)
+							return;
 						PotionData data = meta.getBasePotionData();
 						if (OptionL.getBoolean(Option.HEALING_EXCLUDE_NEGATIVE_POTIONS) && PotionUtil.isNegativePotion(data.getType())) {
 							return;
@@ -170,6 +174,8 @@ public class HealingLeveler extends SkillLeveler implements Listener {
 			if (!(lingeringPotion.getItem().getItemMeta() instanceof PotionMeta)) return;
 			meta = (PotionMeta) lingeringPotion.getItem().getItemMeta();
 		}
+		if (meta == null)
+			return;
 		PotionData data = meta.getBasePotionData();
 
 		if (OptionL.getBoolean(Option.HEALING_EXCLUDE_NEGATIVE_POTIONS) && PotionUtil.isNegativePotion(data.getType())) {

--- a/src/main/java/com/archyx/aureliumskills/skills/healing/HealingSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/healing/HealingSource.java
@@ -49,9 +49,11 @@ public enum HealingSource implements Source {
         ItemStack baseItem = ItemUtils.parseItem(material);
         if (baseItem != null && baseItem.getItemMeta() instanceof PotionMeta) {
             PotionMeta meta = (PotionMeta) baseItem.getItemMeta();
-            meta.setBasePotionData(new PotionData(potionType));
-            meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
-            baseItem.setItemMeta(meta);
+            if (meta != null && potionType != null) {
+                meta.setBasePotionData(new PotionData(potionType));
+                meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+                baseItem.setItemMeta(meta);
+            }
         }
         return baseItem;
     }

--- a/src/main/java/com/archyx/aureliumskills/skills/mining/MiningLeveler.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/mining/MiningLeveler.java
@@ -14,7 +14,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 
-
 public class MiningLeveler extends SkillLeveler implements Listener {
 
 	private final MiningAbilities miningAbilities;

--- a/src/main/java/com/archyx/aureliumskills/skills/mining/MiningSource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/mining/MiningSource.java
@@ -7,7 +7,6 @@ import com.archyx.aureliumskills.source.Source;
 import com.archyx.aureliumskills.util.item.ItemUtils;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 public enum MiningSource implements Source, BlockSource {
 
@@ -92,7 +91,6 @@ public enum MiningSource implements Source, BlockSource {
         this.allowBothIfLegacy = allowBothIfLegacy;
     }
 
-    @Nullable
     @Override
     public String getLegacyMaterial() {
         return legacyMaterial;
@@ -117,7 +115,6 @@ public enum MiningSource implements Source, BlockSource {
         return Skills.MINING;
     }
 
-    @Nullable
     public static MiningSource getSource(Block block) {
         for (MiningSource source : values()) {
             if (source.isMatch(block)) {

--- a/src/main/java/com/archyx/aureliumskills/skills/sorcery/SorcerySource.java
+++ b/src/main/java/com/archyx/aureliumskills/skills/sorcery/SorcerySource.java
@@ -7,7 +7,6 @@ import com.archyx.aureliumskills.source.Source;
 import com.archyx.aureliumskills.util.item.ItemUtils;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.Nullable;
 
 public enum SorcerySource implements Source, BlockSource {
 
@@ -47,7 +46,6 @@ public enum SorcerySource implements Source, BlockSource {
         return ItemUtils.parseItem(material);
     }
 
-    @Nullable
     public static SorcerySource getSource(Block block) {
         for (SorcerySource source : values()) {
             if (source.isMatch(block)) {

--- a/src/main/java/com/archyx/aureliumskills/source/BlockSource.java
+++ b/src/main/java/com/archyx/aureliumskills/source/BlockSource.java
@@ -15,26 +15,27 @@ public interface BlockSource {
     default boolean isMatch(Block block) {
         boolean matched = false;
         String materialName = block.getType().toString();
-        if (XMaterial.isNewVersion() || getLegacyMaterial() == null) { // Standard block handling
+        String legacyMaterial =  getLegacyMaterial();
+        if (XMaterial.isNewVersion() || legacyMaterial == null) { // Standard block handling
             if (toString().equalsIgnoreCase(materialName)) {
                 matched = true;
             }
         } else { // Legacy block handling
             if (getLegacyData() == (byte) -1) { // No data value
                 if (allowBothIfLegacy()) { // Allow both new and legacy material names
-                    if (getLegacyMaterial().equalsIgnoreCase(materialName) || toString().equalsIgnoreCase(materialName)) {
+                    if (legacyMaterial.equalsIgnoreCase(materialName) || toString().equalsIgnoreCase(materialName)) {
                         matched = true;
                     }
-                } else if (getLegacyMaterial().equalsIgnoreCase(materialName)) {
+                } else if (legacyMaterial.equalsIgnoreCase(materialName)) {
                     matched = true;
                 }
             } else { // With data value
                 if (allowBothIfLegacy()) { // Allow both new and legacy material names
-                    if ((getLegacyMaterial().equalsIgnoreCase(materialName) && getLegacyData() == block.getData()
+                    if ((legacyMaterial.equalsIgnoreCase(materialName) && getLegacyData() == block.getData()
                             || (toString().equalsIgnoreCase(materialName) && getLegacyData() == block.getData()))) {
                         matched = true;
                     }
-                } else if (getLegacyMaterial().equalsIgnoreCase(materialName) && getLegacyData() == block.getData()) {
+                } else if (legacyMaterial.equalsIgnoreCase(materialName) && getLegacyData() == block.getData()) {
                     matched = true;
                 }
             }

--- a/src/main/java/com/archyx/aureliumskills/source/Source.java
+++ b/src/main/java/com/archyx/aureliumskills/source/Source.java
@@ -26,10 +26,14 @@ public interface Source extends LootContext {
         if (skill == Skills.ARCHERY || skill == Skills.FIGHTING) {
             messagePath = "sources.mobs." + toString().toLowerCase(Locale.ROOT);
         }
-        String message = Lang.getMessage(new CustomMessageKey(messagePath), locale);
-        if (message == null) {
-            Bukkit.getLogger().warning("[AureliumSkills] Unknown message with path " + messagePath);
-            return messagePath;
+        CustomMessageKey key = new CustomMessageKey(messagePath);
+        String message = messagePath;
+        try {
+            message = Lang.getMessage(key, locale);
+        }
+        catch (IllegalStateException ex) {
+            // No custom message exists when using the message as a key
+            Bukkit.getLogger().warning("[AureliumSkills] Unknown custom message with path: " + key);
         }
         return message;
     }

--- a/src/main/java/com/archyx/aureliumskills/source/SourceManager.java
+++ b/src/main/java/com/archyx/aureliumskills/source/SourceManager.java
@@ -173,7 +173,8 @@ public class SourceManager {
 
     @NotNull
     public List<Source> getTag(SourceTag tag) {
-        return Objects.requireNonNullElseGet(tags.get(tag), ArrayList::new);
+        List<Source> list = tags.get(tag);
+        return list != null ? list : new ArrayList<>();
     }
 
     public Map<XMaterial, Double> getCustomBlocks(Skill skill) {

--- a/src/main/java/com/archyx/aureliumskills/source/SourceManager.java
+++ b/src/main/java/com/archyx/aureliumskills/source/SourceManager.java
@@ -173,7 +173,7 @@ public class SourceManager {
 
     @NotNull
     public List<Source> getTag(SourceTag tag) {
-        return tags.getOrDefault(tag, new ArrayList<>());
+        return Objects.requireNonNullElseGet(tags.get(tag), ArrayList::new);
     }
 
     public Map<XMaterial, Double> getCustomBlocks(Skill skill) {

--- a/src/main/java/com/archyx/aureliumskills/source/SourceManager.java
+++ b/src/main/java/com/archyx/aureliumskills/source/SourceManager.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.InputStream;
@@ -168,10 +167,12 @@ public class SourceManager {
     }
 
     public double getXp(Source source) {
-        return sources.get(source);
+        Double xp = sources.get(source);
+        if (xp == null)
+            throw new IllegalStateException("Invalid xp souce index key: " + source.getPath());
+        return xp;
     }
 
-    @NotNull
     public List<Source> getTag(SourceTag tag) {
         List<Source> list = tags.get(tag);
         return list != null ? list : new ArrayList<>();

--- a/src/main/java/com/archyx/aureliumskills/source/SourceRegistry.java
+++ b/src/main/java/com/archyx/aureliumskills/source/SourceRegistry.java
@@ -11,7 +11,7 @@ import java.util.*;
 public class SourceRegistry {
 
     private final Map<Skill, Class<?>> registry;
-    private final Map<Skill, Source []> sources;
+    private final Map<Skill, Source[]> sources;
 
     public SourceRegistry() {
         registry = new HashMap<>();
@@ -48,7 +48,7 @@ public class SourceRegistry {
         }
     }
 
-    public Source [] values(Skill skill) {
+    public Source[] values(Skill skill) {
         return sources.get(skill);
     }
 

--- a/src/main/java/com/archyx/aureliumskills/source/SourceRegistry.java
+++ b/src/main/java/com/archyx/aureliumskills/source/SourceRegistry.java
@@ -3,7 +3,6 @@ package com.archyx.aureliumskills.source;
 import com.archyx.aureliumskills.skills.Skill;
 import com.archyx.aureliumskills.skills.Skills;
 import com.archyx.aureliumskills.util.text.TextUtil;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -12,7 +11,7 @@ import java.util.*;
 public class SourceRegistry {
 
     private final Map<Skill, Class<?>> registry;
-    private final Map<Skill, Source[]> sources;
+    private final Map<Skill, Source []> sources;
 
     public SourceRegistry() {
         registry = new HashMap<>();
@@ -49,7 +48,7 @@ public class SourceRegistry {
         }
     }
 
-    public Source[] values(Skill skill) {
+    public Source [] values(Skill skill) {
         return sources.get(skill);
     }
 
@@ -61,7 +60,6 @@ public class SourceRegistry {
         return sourceSet;
     }
 
-    @Nullable
     public Source valueOf(String sourceString) {
         for (Source source : values()) {
             if (source.toString().equals(sourceString.toUpperCase(Locale.ROOT))) {

--- a/src/main/java/com/archyx/aureliumskills/stats/Health.java
+++ b/src/main/java/com/archyx/aureliumskills/stats/Health.java
@@ -69,7 +69,10 @@ public class Health implements Listener {
 					setHealth(player);
 					if (plugin.getWorldManager().isDisabledWorld(event.getFrom()) && !plugin.getWorldManager().isInDisabledWorld(player.getLocation())) {
 						if (worldChangeHealth.containsKey(player.getUniqueId())) {
-							player.setHealth(worldChangeHealth.get(player.getUniqueId()));
+							Double health = worldChangeHealth.get(player.getUniqueId());
+							if (health == null)
+								throw new IllegalStateException("Invalid player index key for: " + player.getName());
+							player.setHealth(health);
 							worldChangeHealth.remove(player.getUniqueId());
 						}
 					}
@@ -79,7 +82,10 @@ public class Health implements Listener {
 			setHealth(player);
 			if (plugin.getWorldManager().isDisabledWorld(event.getFrom()) && !plugin.getWorldManager().isInDisabledWorld(player.getLocation())) {
 				if (worldChangeHealth.containsKey(player.getUniqueId())) {
-					player.setHealth(worldChangeHealth.get(player.getUniqueId()));
+					Double health = worldChangeHealth.get(player.getUniqueId());
+					if (health == null)
+						throw new IllegalStateException("Invalid player index key for: " + player.getName());
+					player.setHealth(health);
 					worldChangeHealth.remove(player.getUniqueId());
 				}
 			}
@@ -148,7 +154,9 @@ public class Health implements Listener {
 			player.setHealthScaled(true);
 			int scaledHearts = 0;
 			for (Integer heartNum : hearts.keySet()) {
-				double healthNum = hearts.get(heartNum);
+				Double healthNum = hearts.get(heartNum);
+				if (healthNum == null)
+					throw new IllegalStateException("Invalid heart index key [" + heartNum + "] for player: " + player.getName());
 				if (health >= healthNum) {
 					if (heartNum > scaledHearts) {
 						scaledHearts = heartNum;

--- a/src/main/java/com/archyx/aureliumskills/stats/Luck.java
+++ b/src/main/java/com/archyx/aureliumskills/stats/Luck.java
@@ -136,14 +136,16 @@ public class Luck implements Listener {
 										}
 									}
 								}
-								else if (mat.equals(XMaterial.GRASS_BLOCK.parseMaterial())) {
+								else {
 									Material grassBlock = XMaterial.GRASS_BLOCK.parseMaterial();
 									if (grassBlock == null)
 										return;
-									PlayerLootDropEvent dropEvent = new PlayerLootDropEvent(player, new ItemStack(grassBlock), block.getLocation().add(0.5, 0.5, 0.5), LootDropCause.LUCK_DOUBLE_DROP);
-									Bukkit.getPluginManager().callEvent(dropEvent);
-									if (!event.isCancelled()) {
-										block.getWorld().dropItem(dropEvent.getLocation(), dropEvent.getItemStack());
+									if (mat.equals(grassBlock)) {
+										PlayerLootDropEvent dropEvent = new PlayerLootDropEvent(player, new ItemStack(grassBlock), block.getLocation().add(0.5, 0.5, 0.5), LootDropCause.LUCK_DOUBLE_DROP);
+										Bukkit.getPluginManager().callEvent(dropEvent);
+										if (!event.isCancelled()) {
+											block.getWorld().dropItem(dropEvent.getLocation(), dropEvent.getItemStack());
+										}
 									}
 								}
 							}

--- a/src/main/java/com/archyx/aureliumskills/stats/Luck.java
+++ b/src/main/java/com/archyx/aureliumskills/stats/Luck.java
@@ -8,6 +8,7 @@ import com.archyx.aureliumskills.configuration.OptionL;
 import com.archyx.aureliumskills.data.PlayerData;
 import com.archyx.aureliumskills.data.PlayerDataLoadEvent;
 import com.archyx.aureliumskills.support.WorldGuardFlags;
+import com.archyx.aureliumskills.support.WorldGuardSupport;
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -88,12 +89,13 @@ public class Luck implements Listener {
 				return;
 			}
 			//Checks if in blocked region
-			if (plugin.isWorldGuardEnabled()) {
-				if (plugin.getWorldGuardSupport().isInBlockedRegion(block.getLocation())) {
+            WorldGuardSupport worldGuardSupport = plugin.getWorldGuardSupport();
+            if (plugin.isWorldGuardEnabled() && worldGuardSupport != null) {
+				if (worldGuardSupport.isInBlockedRegion(block.getLocation())) {
 					return;
 				}
 				// Check if blocked by flags
-				else if (plugin.getWorldGuardSupport().blockedByFlag(block.getLocation(), player, WorldGuardFlags.FlagKey.XP_GAIN)) {
+				else if (worldGuardSupport.blockedByFlag(block.getLocation(), player, WorldGuardFlags.FlagKey.XP_GAIN)) {
 					return;
 				}
 			}

--- a/src/main/java/com/archyx/aureliumskills/stats/Luck.java
+++ b/src/main/java/com/archyx/aureliumskills/stats/Luck.java
@@ -138,6 +138,8 @@ public class Luck implements Listener {
 								}
 								else if (mat.equals(XMaterial.GRASS_BLOCK.parseMaterial())) {
 									Material grassBlock = XMaterial.GRASS_BLOCK.parseMaterial();
+									if (grassBlock == null)
+										return;
 									PlayerLootDropEvent dropEvent = new PlayerLootDropEvent(player, new ItemStack(grassBlock), block.getLocation().add(0.5, 0.5, 0.5), LootDropCause.LUCK_DOUBLE_DROP);
 									Bukkit.getPluginManager().callEvent(dropEvent);
 									if (!event.isCancelled()) {

--- a/src/main/java/com/archyx/aureliumskills/stats/StatRegistry.java
+++ b/src/main/java/com/archyx/aureliumskills/stats/StatRegistry.java
@@ -1,7 +1,5 @@
 package com.archyx.aureliumskills.stats;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
@@ -23,7 +21,6 @@ public class StatRegistry {
         return stats.values();
     }
 
-    @Nullable
     public Stat getStat(String key) {
         return this.stats.get(key.toLowerCase(Locale.ROOT));
     }

--- a/src/main/java/com/archyx/aureliumskills/support/HologramSupport.java
+++ b/src/main/java/com/archyx/aureliumskills/support/HologramSupport.java
@@ -55,12 +55,14 @@ public class HologramSupport implements Listener {
                         } else if (event.getDamager() instanceof Projectile) {
                             Projectile projectile = (Projectile) event.getDamager();
                             if (projectile.getShooter() instanceof Player) {
-                                Player player = (Player) projectile.getShooter();
-                                if (player.equals(event.getEntity())) { // Don't display self damage
+                                Player shooter = (Player) projectile.getShooter();
+                                if (shooter == null)
+                                    return;
+                                if (shooter.equals(event.getEntity())) { // Don't display self damage
                                     return;
                                 }
                                 if (event.getFinalDamage() <= 0) return; // Don't display 0 damage
-                                if (player.hasMetadata("skillsCritical")) {
+                                if (shooter.hasMetadata("skillsCritical")) {
                                     createHologram(getLocation(event.getEntity()), getText(event.getFinalDamage(), true));
                                 } else {
                                     createHologram(getLocation(event.getEntity()), getText(event.getFinalDamage(), false));

--- a/src/main/java/com/archyx/aureliumskills/support/PlaceholderSupport.java
+++ b/src/main/java/com/archyx/aureliumskills/support/PlaceholderSupport.java
@@ -140,7 +140,6 @@ public class PlaceholderSupport extends PlaceholderExpansion {
         //Gets stat values
         for (Stat stat : plugin.getStatRegistry().getStats()) {
             String name = stat.name();
-            assert (null != name);
             if (identifier.equals(name.toLowerCase(Locale.ENGLISH))) {
                 PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
                 if (playerData != null) {
@@ -172,7 +171,6 @@ public class PlaceholderSupport extends PlaceholderExpansion {
 
         if (identifier.startsWith("lb_")) {
             String leaderboardType = TextUtil.replace(identifier, "lb_", "");
-            assert (null != leaderboardType);
             if (leaderboardType.startsWith("power_")) {
                 int place = NumberUtil.toInt(TextUtil.replace(leaderboardType, "power_", ""));
                 if (place > 0) {
@@ -259,7 +257,6 @@ public class PlaceholderSupport extends PlaceholderExpansion {
 
         if (identifier.startsWith("rank_")) {
             String skillName = TextUtil.replace(identifier, "rank_", "");
-            assert (null != skillName);
             Skill skill = plugin.getSkillRegistry().getSkill(skillName);
             if (skill != null) {
                 return String.valueOf(plugin.getLeaderboardManager().getSkillRank(skill, player.getUniqueId()));
@@ -269,7 +266,6 @@ public class PlaceholderSupport extends PlaceholderExpansion {
         for (String id : xpIdentifiers) {
             if (identifier.startsWith(id)) {
                 String skillName = TextUtil.replace(identifier, id, "");
-                assert (null != skillName);
                 Skill skill = plugin.getSkillRegistry().getSkill(skillName);
                 if (skill != null) {
                     PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
@@ -302,7 +298,6 @@ public class PlaceholderSupport extends PlaceholderExpansion {
                 return NumberUtil.format2(plugin.getLeveler().getMultiplier(player));
             }
             String skillName = TextUtil.replace(identifier, "multiplier_", "");
-            assert (null != skillName);
             Skill skill = plugin.getSkillRegistry().getSkill(skillName);
             if (skill != null) {
                 return NumberUtil.format2(plugin.getLeveler().getMultiplier(player, skill));
@@ -314,7 +309,6 @@ public class PlaceholderSupport extends PlaceholderExpansion {
                 return String.valueOf(Math.round((plugin.getLeveler().getMultiplier(player) - 1) * 100));
             }
             String skillName = TextUtil.replace(identifier, "multiplier_percent_", "");
-            assert (null != skillName);
             Skill skill = plugin.getSkillRegistry().getSkill(skillName);
             if (skill != null) {
                 return String.valueOf(Math.round((plugin.getLeveler().getMultiplier(player, skill) - 1) * 100));

--- a/src/main/java/com/archyx/aureliumskills/support/PlaceholderSupport.java
+++ b/src/main/java/com/archyx/aureliumskills/support/PlaceholderSupport.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 public class PlaceholderSupport extends PlaceholderExpansion {
 
     private final AureliumSkills plugin;
-    private final String[] xpIdentifiers = new String[] {"xp_required_formatted_", "xp_required_", "xp_progress_int_", "xp_progress_1_", "xp_progress_", "xp_int_", "xp_formatted_", "xp_"};
+    private final String[] xpIdentifiers = {"xp_required_formatted_", "xp_required_", "xp_progress_int_", "xp_progress_1_", "xp_progress_", "xp_int_", "xp_formatted_", "xp_"};
 
     public PlaceholderSupport(AureliumSkills plugin) {
         this.plugin = plugin;
@@ -139,12 +139,14 @@ public class PlaceholderSupport extends PlaceholderExpansion {
 
         //Gets stat values
         for (Stat stat : plugin.getStatRegistry().getStats()) {
-            if (identifier.equals(stat.name().toLowerCase(Locale.ENGLISH))) {
+            String name = stat.name();
+            assert (null != name);
+            if (identifier.equals(name.toLowerCase(Locale.ENGLISH))) {
                 PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
                 if (playerData != null) {
                     return String.valueOf(playerData.getStatLevel(stat));
                 }
-            } else if (identifier.equals(stat.name().toLowerCase(Locale.ROOT) + "_int")) {
+            } else if (identifier.equals(name.toLowerCase(Locale.ROOT) + "_int")) {
                 PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
                 if (playerData != null) {
                     return String.valueOf(Math.round(playerData.getStatLevel(stat)));
@@ -170,6 +172,7 @@ public class PlaceholderSupport extends PlaceholderExpansion {
 
         if (identifier.startsWith("lb_")) {
             String leaderboardType = TextUtil.replace(identifier, "lb_", "");
+            assert (null != leaderboardType);
             if (leaderboardType.startsWith("power_")) {
                 int place = NumberUtil.toInt(TextUtil.replace(leaderboardType, "power_", ""));
                 if (place > 0) {
@@ -256,6 +259,7 @@ public class PlaceholderSupport extends PlaceholderExpansion {
 
         if (identifier.startsWith("rank_")) {
             String skillName = TextUtil.replace(identifier, "rank_", "");
+            assert (null != skillName);
             Skill skill = plugin.getSkillRegistry().getSkill(skillName);
             if (skill != null) {
                 return String.valueOf(plugin.getLeaderboardManager().getSkillRank(skill, player.getUniqueId()));
@@ -265,7 +269,7 @@ public class PlaceholderSupport extends PlaceholderExpansion {
         for (String id : xpIdentifiers) {
             if (identifier.startsWith(id)) {
                 String skillName = TextUtil.replace(identifier, id, "");
-
+                assert (null != skillName);
                 Skill skill = plugin.getSkillRegistry().getSkill(skillName);
                 if (skill != null) {
                     PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
@@ -298,6 +302,7 @@ public class PlaceholderSupport extends PlaceholderExpansion {
                 return NumberUtil.format2(plugin.getLeveler().getMultiplier(player));
             }
             String skillName = TextUtil.replace(identifier, "multiplier_", "");
+            assert (null != skillName);
             Skill skill = plugin.getSkillRegistry().getSkill(skillName);
             if (skill != null) {
                 return NumberUtil.format2(plugin.getLeveler().getMultiplier(player, skill));
@@ -309,6 +314,7 @@ public class PlaceholderSupport extends PlaceholderExpansion {
                 return String.valueOf(Math.round((plugin.getLeveler().getMultiplier(player) - 1) * 100));
             }
             String skillName = TextUtil.replace(identifier, "multiplier_percent_", "");
+            assert (null != skillName);
             Skill skill = plugin.getSkillRegistry().getSkill(skillName);
             if (skill != null) {
                 return String.valueOf(Math.round((plugin.getLeveler().getMultiplier(player, skill) - 1) * 100));

--- a/src/main/java/com/archyx/aureliumskills/support/WorldGuardFlags.java
+++ b/src/main/java/com/archyx/aureliumskills/support/WorldGuardFlags.java
@@ -7,7 +7,6 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import org.bukkit.Bukkit;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -21,7 +20,6 @@ public class WorldGuardFlags {
         this.stateFlags = new HashMap<>();
     }
 
-    @Nullable
     public StateFlag getStateFlag(FlagKey flagKey) {
         return stateFlags.get(flagKey);
     }

--- a/src/main/java/com/archyx/aureliumskills/ui/ActionBar.java
+++ b/src/main/java/com/archyx/aureliumskills/ui/ActionBar.java
@@ -65,13 +65,11 @@ public class ActionBar implements Listener {
 								PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
 								if (playerData != null) {
 									Locale locale = playerData.getLocale();
-									String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.IDLE, locale)
+									sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.IDLE, locale)
 											, "{hp}", getHp(player)
 											, "{max_hp}", getMaxHp(player)
 											, "{mana}", getMana(playerData)
-											, "{max_mana}", getMaxMana(playerData));
-									assert (null != m);
-									sendActionBar(player, m);
+											, "{max_mana}", getMaxMana(playerData)));
 								}
 							}
 						}
@@ -119,8 +117,13 @@ public class ActionBar implements Listener {
 						currentAction.put(player, 0);
 					}
 					//Add to current action
-					currentAction.put(player, currentAction.get(player) + 1);
-					int thisAction = this.currentAction.get(player);
+					Integer action = currentAction.get(player);
+					if (action == null) {
+						plugin.getLogger().warning("Current action is not cached for player: " + player.getName());
+						return;
+					}
+					int thisAction = action + 1;
+					currentAction.put(player, thisAction);
 					new BukkitRunnable() {
 						@Override
 						public void run() {
@@ -137,7 +140,7 @@ public class ActionBar implements Listener {
 												// Xp gained
 												if (xpAmount >= 0) {
 													if (!OptionL.getBoolean(Option.ACTION_BAR_ROUND_XP)) {
-														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
+														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_gained}", NumberUtil.format1(xpAmount)
@@ -145,12 +148,10 @@ public class ActionBar implements Listener {
 																, "{current_xp}", NumberUtil.format1(playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData));
-														assert (null != m);
-														sendActionBar(player, m);
+																, "{max_mana}", getMaxMana(playerData)));
 													}
 													else {
-														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
+														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_gained}", NumberUtil.format1(xpAmount)
@@ -158,15 +159,13 @@ public class ActionBar implements Listener {
 																, "{current_xp}", String.valueOf((int) playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData));
-														assert (null != m);
-														sendActionBar(player, m);
+																, "{max_mana}", getMaxMana(playerData)));
 													}
 												}
 												// Xp removed
 												else {
 													if (!OptionL.getBoolean(Option.ACTION_BAR_ROUND_XP)) {
-														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP_REMOVED, locale)
+														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP_REMOVED, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_removed}", NumberUtil.format1(xpAmount)
@@ -174,12 +173,10 @@ public class ActionBar implements Listener {
 																, "{current_xp}", NumberUtil.format1(playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData));
-														assert (null != m);
-														sendActionBar(player, m);
+																, "{max_mana}", getMaxMana(playerData)));
 													}
 													else {
-														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
+														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_gained}", NumberUtil.format1(xpAmount)
@@ -187,9 +184,7 @@ public class ActionBar implements Listener {
 																, "{current_xp}", String.valueOf((int) playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData));
-														assert (null != m);
-														sendActionBar(player, m);
+																, "{max_mana}", getMaxMana(playerData)));
 													}
 												}
 											}
@@ -199,27 +194,23 @@ public class ActionBar implements Listener {
 											if (OptionL.getBoolean(Option.ACTION_BAR_MAXED)) {
 												// Xp gained
 												if (xpAmount >= 0) {
-													String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED, locale)
+													sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED, locale)
 															, "{hp}", getHp(player)
 															, "{max_hp}", getMaxHp(player)
 															, "{xp_gained}", NumberUtil.format1(xpAmount)
 															, "{skill}", skill.getDisplayName(locale)
 															, "{mana}", getMana(playerData)
-															, "{max_mana}", getMaxMana(playerData));
-													assert (null != m);
-													sendActionBar(player, m);
+															, "{max_mana}", getMaxMana(playerData)));
 												}
 												// Xp removed
 												else {
-													String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED_REMOVED, locale)
+													sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED_REMOVED, locale)
 															, "{hp}", getHp(player)
 															, "{max_hp}", getMaxHp(player)
 															, "{xp_removed}", NumberUtil.format1(xpAmount)
 															, "{skill}", skill.getDisplayName(locale)
 															, "{mana}", getMana(playerData)
-															, "{max_mana}", getMaxMana(playerData));
-													assert (null != m);
-													sendActionBar(player, m);
+															, "{max_mana}", getMaxMana(playerData)));
 												}
 											}
 										}
@@ -258,14 +249,12 @@ public class ActionBar implements Listener {
 		if (!actionBarDisabled.contains(player.getUniqueId())) {
 			PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
 			if (playerData == null) return;
-			String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.ABILITY, playerData.getLocale()),
+			sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.ABILITY, playerData.getLocale()),
 					"{hp}", getHp(player),
 					"{max_hp}", getMaxHp(player),
 					"{mana}", getMana(playerData),
 					"{max_mana}", getMaxMana(playerData),
-					"{message}", message);
-			assert (null != m);
-			sendActionBar(player, m);
+					"{message}", message));
 			setPaused(player, 40);
 		}
 	}
@@ -331,7 +320,9 @@ public class ActionBar implements Listener {
 		} else {
 			currentAction.put(player, 0);
 		}
-		int thisAction = this.currentAction.get(player);
+		Integer thisAction = this.currentAction.get(player);
+		if (thisAction == null)
+			throw new IllegalStateException("Invalid player index key for: " + player.getName());
 		new BukkitRunnable() {
 			@Override
 			public void run() {
@@ -466,7 +457,7 @@ public class ActionBar implements Listener {
 				if (item != null) {
 					if (item.getType().isBlock()) {
 						if (block.getY() == block.getWorld().getMaxHeight() - 1) {
-							if (event.getBlockFace() == BlockFace.UP)	 {
+							if (event.getBlockFace() == BlockFace.UP)	{
 								setPaused(player, 40);
 							}
 						}

--- a/src/main/java/com/archyx/aureliumskills/ui/ActionBar.java
+++ b/src/main/java/com/archyx/aureliumskills/ui/ActionBar.java
@@ -65,11 +65,13 @@ public class ActionBar implements Listener {
 								PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
 								if (playerData != null) {
 									Locale locale = playerData.getLocale();
-									sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.IDLE, locale)
+									String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.IDLE, locale)
 											, "{hp}", getHp(player)
 											, "{max_hp}", getMaxHp(player)
 											, "{mana}", getMana(playerData)
-											, "{max_mana}", getMaxMana(playerData)));
+											, "{max_mana}", getMaxMana(playerData));
+									assert (null != m);
+									sendActionBar(player, m);
 								}
 							}
 						}
@@ -135,7 +137,7 @@ public class ActionBar implements Listener {
 												// Xp gained
 												if (xpAmount >= 0) {
 													if (!OptionL.getBoolean(Option.ACTION_BAR_ROUND_XP)) {
-														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
+														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_gained}", NumberUtil.format1(xpAmount)
@@ -143,10 +145,12 @@ public class ActionBar implements Listener {
 																, "{current_xp}", NumberUtil.format1(playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData)));
+																, "{max_mana}", getMaxMana(playerData));
+														assert (null != m);
+														sendActionBar(player, m);
 													}
 													else {
-														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
+														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_gained}", NumberUtil.format1(xpAmount)
@@ -154,13 +158,15 @@ public class ActionBar implements Listener {
 																, "{current_xp}", String.valueOf((int) playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData)));
+																, "{max_mana}", getMaxMana(playerData));
+														assert (null != m);
+														sendActionBar(player, m);
 													}
 												}
 												// Xp removed
 												else {
 													if (!OptionL.getBoolean(Option.ACTION_BAR_ROUND_XP)) {
-														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP_REMOVED, locale)
+														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP_REMOVED, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_removed}", NumberUtil.format1(xpAmount)
@@ -168,10 +174,12 @@ public class ActionBar implements Listener {
 																, "{current_xp}", NumberUtil.format1(playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData)));
+																, "{max_mana}", getMaxMana(playerData));
+														assert (null != m);
+														sendActionBar(player, m);
 													}
 													else {
-														sendActionBar(player, TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
+														String m = TextUtil.replace(TextUtil.replace(Lang.getMessage(ActionBarMessage.XP, locale)
 																, "{hp}", getHp(player)
 																, "{max_hp}", getMaxHp(player)
 																, "{xp_gained}", NumberUtil.format1(xpAmount)
@@ -179,7 +187,9 @@ public class ActionBar implements Listener {
 																, "{current_xp}", String.valueOf((int) playerData.getSkillXp(skill)))
 																, "{level_xp}", BigNumber.withSuffix(plugin.getLeveler().getXpRequirements().getXpRequired(skill, playerData.getSkillLevel(skill) + 1))
 																, "{mana}", getMana(playerData)
-																, "{max_mana}", getMaxMana(playerData)));
+																, "{max_mana}", getMaxMana(playerData));
+														assert (null != m);
+														sendActionBar(player, m);
 													}
 												}
 											}
@@ -189,23 +199,27 @@ public class ActionBar implements Listener {
 											if (OptionL.getBoolean(Option.ACTION_BAR_MAXED)) {
 												// Xp gained
 												if (xpAmount >= 0) {
-													sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED, locale)
+													String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED, locale)
 															, "{hp}", getHp(player)
 															, "{max_hp}", getMaxHp(player)
 															, "{xp_gained}", NumberUtil.format1(xpAmount)
 															, "{skill}", skill.getDisplayName(locale)
 															, "{mana}", getMana(playerData)
-															, "{max_mana}", getMaxMana(playerData)));
+															, "{max_mana}", getMaxMana(playerData));
+													assert (null != m);
+													sendActionBar(player, m);
 												}
 												// Xp removed
 												else {
-													sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED_REMOVED, locale)
+													String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.MAXED_REMOVED, locale)
 															, "{hp}", getHp(player)
 															, "{max_hp}", getMaxHp(player)
 															, "{xp_removed}", NumberUtil.format1(xpAmount)
 															, "{skill}", skill.getDisplayName(locale)
 															, "{mana}", getMana(playerData)
-															, "{max_mana}", getMaxMana(playerData)));
+															, "{max_mana}", getMaxMana(playerData));
+													assert (null != m);
+													sendActionBar(player, m);
 												}
 											}
 										}
@@ -244,12 +258,14 @@ public class ActionBar implements Listener {
 		if (!actionBarDisabled.contains(player.getUniqueId())) {
 			PlayerData playerData = plugin.getPlayerManager().getPlayerData(player);
 			if (playerData == null) return;
-			sendActionBar(player, TextUtil.replace(Lang.getMessage(ActionBarMessage.ABILITY, playerData.getLocale()),
+			String m = TextUtil.replace(Lang.getMessage(ActionBarMessage.ABILITY, playerData.getLocale()),
 					"{hp}", getHp(player),
 					"{max_hp}", getMaxHp(player),
 					"{mana}", getMana(playerData),
 					"{max_mana}", getMaxMana(playerData),
-					"{message}", message));
+					"{message}", message);
+			assert (null != m);
+			sendActionBar(player, m);
 			setPaused(player, 40);
 		}
 	}

--- a/src/main/java/com/archyx/aureliumskills/ui/ActionBar.java
+++ b/src/main/java/com/archyx/aureliumskills/ui/ActionBar.java
@@ -7,6 +7,7 @@ import com.archyx.aureliumskills.data.PlayerData;
 import com.archyx.aureliumskills.lang.ActionBarMessage;
 import com.archyx.aureliumskills.lang.Lang;
 import com.archyx.aureliumskills.skills.Skill;
+import com.archyx.aureliumskills.support.ProtocolLibSupport;
 import com.archyx.aureliumskills.util.math.BigNumber;
 import com.archyx.aureliumskills.util.math.NumberUtil;
 import com.archyx.aureliumskills.util.text.TextUtil;
@@ -283,11 +284,12 @@ public class ActionBar implements Listener {
 		if (OptionL.getBoolean(Option.ACTION_BAR_PLACEHOLDER_API) && plugin.isPlaceholderAPIEnabled()) {
 			message = PlaceholderAPI.setPlaceholders(player, message);
 		}
-		if (plugin.isProtocolLibEnabled()) {
+		ProtocolLibSupport protocolLibSupport = plugin.getProtocolLibSupport();
+		if (plugin.isProtocolLibEnabled() && protocolLibSupport != null) {
 			if (VersionUtils.isAtLeastVersion(17)) {
-				plugin.getProtocolLibSupport().sendNewActionBar(player, message);
+				protocolLibSupport.sendNewActionBar(player, message);
 			} else {
-				plugin.getProtocolLibSupport().sendLegacyActionBar(player, message);
+				protocolLibSupport.sendLegacyActionBar(player, message);
 			}
 		} else {
 			player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));

--- a/src/main/java/com/archyx/aureliumskills/ui/SkillBossBar.java
+++ b/src/main/java/com/archyx/aureliumskills/ui/SkillBossBar.java
@@ -116,7 +116,7 @@ public class SkillBossBar implements Listener {
             if (!bossBars.containsKey(player)) bossBars.put(player, new HashMap<>());
             Map<Skill, BossBar> bars = bossBars.get(player);
             if (bars == null)
-                throw new IllegalStateException("Invalid boss bar player index key: " + player);
+                throw new IllegalStateException("Invalid boss bar player index key: " + player.getName());
             bossBar = bars.get(skill);
         }
         // If player does not have a boss bar in that skill

--- a/src/main/java/com/archyx/aureliumskills/ui/SkillBossBar.java
+++ b/src/main/java/com/archyx/aureliumskills/ui/SkillBossBar.java
@@ -114,7 +114,10 @@ public class SkillBossBar implements Listener {
         }
         else {
             if (!bossBars.containsKey(player)) bossBars.put(player, new HashMap<>());
-            bossBar = bossBars.get(player).get(skill);
+            Map<Skill, BossBar> bars = bossBars.get(player);
+            if (bars == null)
+                throw new IllegalStateException("Invalid boss bar player index key: " + player);
+            bossBar = bars.get(skill);
         }
         // If player does not have a boss bar in that skill
         if (bossBar == null) {
@@ -152,7 +155,10 @@ public class SkillBossBar implements Listener {
                 singleBossBars.put(player, bossBar);
             }
             else {
-                bossBars.get(player).put(skill, bossBar);
+                Map<Skill, BossBar> bars = bossBars.get(player);
+                if (bars == null)
+                    throw new IllegalStateException("Invalid boss bar player index key " + player.getName());
+                bars.put(skill, bossBar);
             }
         }
         // Use existing one
@@ -198,37 +204,51 @@ public class SkillBossBar implements Listener {
             }
         }
         else {
-            if (!currentActions.containsKey(player)) currentActions.put(player, new HashMap<>());
-            Integer currentAction = currentActions.get(player).get(skill);
+            Map<Skill, Integer> actions = checkCurrentActions.get(player);
+            if (actions == null) {
+                actions = new HashMap<>();
+                checkCurrentActions.put(player, actions);
+            }
+            Integer currentAction = actions.get(skill);
             if (currentAction != null) {
-                currentActions.get(player).put(skill, currentAction + 1);
+                actions.put(skill, currentAction + 1);
             } else {
-                currentActions.get(player).put(skill, 0);
+                actions.put(skill, 0);
             }
         }
         scheduleHide(player, skill, bossBar);
     }
 
     public void incrementAction(Player player, Skill skill) {
-        if (!singleCheckCurrentActions.containsKey(player)) singleCheckCurrentActions.put(player, 0);
-        if (!checkCurrentActions.containsKey(player)) checkCurrentActions.put(player, new HashMap<>());
+        Map<Skill, Integer> actions = checkCurrentActions.get(player);
+        if (actions == null) {
+            actions = new HashMap<>();
+            checkCurrentActions.put(player, actions);
+        }
+        Integer currentAction = singleCheckCurrentActions.get(player);
+        if (currentAction == null) {
+            currentAction = 0;
+            singleCheckCurrentActions.put(player, currentAction);
+        }
         // Increment current action
         if (mode.equals("single")) {
-            singleCheckCurrentActions.put(player, singleCheckCurrentActions.get(player) + 1);
+            singleCheckCurrentActions.put(player, currentAction + 1);
         }
         else {
-            Integer currentAction = checkCurrentActions.get(player).get(skill);
+            currentAction = actions.get(skill);
             if (currentAction != null) {
-                checkCurrentActions.get(player).put(skill, currentAction + 1);
+                actions.put(skill, currentAction + 1);
             } else {
-                checkCurrentActions.get(player).put(skill, 0);
+                actions.put(skill, 0);
             }
         }
     }
 
     private void scheduleHide(Player player, Skill skill, BossBar bossBar) {
         if (mode.equals("single")) {
-            final int currentAction = singleCurrentActions.get(player);
+            Integer currentAction = singleCurrentActions.get(player);
+            if (currentAction == null)
+                throw new IllegalStateException("Invalid boss bar actions index key: " + player.getName());
             new BukkitRunnable() {
                 @Override
                 public void run() {
@@ -244,7 +264,9 @@ public class SkillBossBar implements Listener {
         else {
             Map<Skill, Integer> multiCurrentActions = currentActions.get(player);
             if (multiCurrentActions != null) {
-                final int currentAction = multiCurrentActions.get(skill);
+                Integer currentAction = multiCurrentActions.get(skill);
+                if (currentAction == null)
+                    throw new IllegalStateException("Invalid boss bar actions index key: " + player.getName());
                 new BukkitRunnable() {
                     @Override
                     public void run() {
@@ -277,12 +299,18 @@ public class SkillBossBar implements Listener {
 
     public int getCurrentAction(Player player, Skill skill) {
         if (mode.equals("single")) {
-            return singleCheckCurrentActions.get(player);
+            Integer currentAction = singleCheckCurrentActions.get(player);
+            if (currentAction == null)
+                throw new IllegalStateException("Invalid boss bar actions index key: " + player.getName());
+            return currentAction;
         }
         else {
             Map<Skill, Integer> multiCurrentActions = checkCurrentActions.get(player);
             if (multiCurrentActions != null) {
-                return multiCurrentActions.get(skill);
+            Integer currentAction = multiCurrentActions.get(skill);
+            if (currentAction == null)
+                throw new IllegalStateException("Invalid boss bar actions index key: " + player.getName());
+                return currentAction;
             }
         }
         return -1;

--- a/src/main/java/com/archyx/aureliumskills/util/armor/ArmorListener.java
+++ b/src/main/java/com/archyx/aureliumskills/util/armor/ArmorListener.java
@@ -3,6 +3,7 @@ package com.archyx.aureliumskills.util.armor;
 import com.archyx.aureliumskills.util.armor.ArmorEquipEvent.EquipMethod;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
@@ -14,6 +15,7 @@ import org.bukkit.event.inventory.*;
 import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -65,7 +67,10 @@ public class ArmorListener implements Listener{
             numberkey = true;
         }
         if(e.getSlotType() != SlotType.ARMOR && e.getSlotType() != SlotType.QUICKBAR && e.getSlotType() != SlotType.CONTAINER) return;
-        if(e.getClickedInventory() != null && !e.getClickedInventory().getType().equals(InventoryType.PLAYER)) return;
+        Inventory inventory = e.getClickedInventory();
+        if (inventory == null)
+            return;
+        if(!inventory.getType().equals(InventoryType.PLAYER)) return;
         if (!e.getInventory().getType().equals(InventoryType.CRAFTING) && !e.getInventory().getType().equals(InventoryType.PLAYER)) return;
         if(!(e.getWhoClicked() instanceof Player)) return;
         ArmorType newArmorType = ArmorType.matchType(shift ? e.getCurrentItem() : e.getCursor());
@@ -92,16 +97,16 @@ public class ArmorListener implements Listener{
             ItemStack newArmorPiece = e.getCursor();
             ItemStack oldArmorPiece = e.getCurrentItem();
             if(numberkey){
-                if(e.getClickedInventory().getType().equals(InventoryType.PLAYER)){// Prevents shit in the 2by2 crafting
+                if(inventory.getType().equals(InventoryType.PLAYER)){// Prevents shit in the 2by2 crafting
                     // e.getClickedInventory() == The players inventory
                     // e.getHotBarButton() == key people are pressing to equip or unequip the item to or from.
                     // e.getRawSlot() == The slot the item is going to.
                     // e.getSlot() == Armor slot, can't use e.getRawSlot() as that gives a hotbar slot ;-;
-                    ItemStack hotbarItem = e.getClickedInventory().getItem(e.getHotbarButton());
+                    ItemStack hotbarItem = inventory.getItem(e.getHotbarButton());
                     if(!isAirOrNull(hotbarItem)){// Equipping
                         newArmorType = ArmorType.matchType(hotbarItem);
                         newArmorPiece = hotbarItem;
-                        oldArmorPiece = e.getClickedInventory().getItem(e.getSlot());
+                        oldArmorPiece = inventory.getItem(e.getSlot());
                     }else{// Unequipping
                         newArmorType = ArmorType.matchType(!isAirOrNull(e.getCurrentItem()) ? e.getCurrentItem() : e.getCursor());
                     }
@@ -134,7 +139,10 @@ public class ArmorListener implements Listener{
         if(e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK){
             Player player = e.getPlayer();
             if (e.getItem() != null) {
-                Material mat = e.getItem().getType();
+                ItemStack itemStack = e.getItem();
+                if (itemStack == null)
+                    return;
+                Material mat = itemStack.getType();
                 if (mat.name().endsWith("_HEAD") || mat.name().endsWith("_SKULL") || mat.name().endsWith("SKULL_ITEM")) {
                     return;
                 }
@@ -142,7 +150,10 @@ public class ArmorListener implements Listener{
             if(!e.useInteractedBlock().equals(Result.DENY)){
                 if(e.getClickedBlock() != null && e.getAction() == Action.RIGHT_CLICK_BLOCK && !player.isSneaking()){// Having both of these checks is useless, might as well do it though.
                     // Some blocks have actions when you right click them which stops the client from equipping the armor in hand.
-                    Material mat = e.getClickedBlock().getType();
+                    Block clickedBlock = e.getClickedBlock();
+                    if (clickedBlock == null)
+                        return;
+                    Material mat = clickedBlock.getType();
                     for (String s : blockedMaterials){
                         String[] split = s.split("!");
                         String checked = split[0];

--- a/src/main/java/com/archyx/aureliumskills/util/armor/ArmorType.java
+++ b/src/main/java/com/archyx/aureliumskills/util/armor/ArmorType.java
@@ -25,6 +25,7 @@ public enum ArmorType{
      */
     public static ArmorType matchType(final ItemStack itemStack){
         if(ArmorListener.isAirOrNull(itemStack)) return null;
+        assert (null != itemStack);
         String type = itemStack.getType().name();
         if(type.endsWith("_HELMET") || type.endsWith("_SKULL") || type.endsWith("_HEAD") || type.endsWith("SKULL_ITEM")) return HELMET;
         else if(type.endsWith("_CHESTPLATE") || type.equals("ELYTRA")) return CHESTPLATE;

--- a/src/main/java/com/archyx/aureliumskills/util/block/BlockFaceUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/block/BlockFaceUtil.java
@@ -2,14 +2,15 @@ package com.archyx.aureliumskills.util.block;
 
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class BlockFaceUtil {
-    static final BlockFace[] faces = {BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN};
+    static final BlockFace @NotNull[] faces = {BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN};
     
-    public static final BlockFace[] getBlockSides() {
+    public static final BlockFace @NotNull[] getBlockSides() {
         return faces;
     }
 

--- a/src/main/java/com/archyx/aureliumskills/util/block/BlockFaceUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/block/BlockFaceUtil.java
@@ -7,9 +7,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BlockFaceUtil {
-
-    public static BlockFace[] getBlockSides() {
-        return new BlockFace[] {BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN};
+    static final BlockFace[] faces = {BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN};
+    
+    public static final BlockFace[] getBlockSides() {
+        return faces;
     }
 
     public static List<Block> getSurroundingBlocks(Block block) {

--- a/src/main/java/com/archyx/aureliumskills/util/entity/EntityData.java
+++ b/src/main/java/com/archyx/aureliumskills/util/entity/EntityData.java
@@ -79,6 +79,7 @@ public class EntityData extends Parser {
         entity.setCustomNameVisible(customNameVisible);
         entity.setCustomName(customName);
         for (String scoreboardTag : scoreboardTags) {
+            assert (scoreboardTag != null);
             entity.addScoreboardTag(scoreboardTag);
         }
     }

--- a/src/main/java/com/archyx/aureliumskills/util/entity/EntityData.java
+++ b/src/main/java/com/archyx/aureliumskills/util/entity/EntityData.java
@@ -6,7 +6,6 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +49,6 @@ public class EntityData extends Parser {
      * @param location The location to spawn
      * @return The Entity spawned, null if the location does not have a World
      */
-    @Nullable
     public Entity spawn(Location location) {
         // Spawn entity
         World world = location.getWorld();
@@ -79,7 +77,6 @@ public class EntityData extends Parser {
         entity.setCustomNameVisible(customNameVisible);
         entity.setCustomName(customName);
         for (String scoreboardTag : scoreboardTags) {
-            assert (scoreboardTag != null);
             entity.addScoreboardTag(scoreboardTag);
         }
     }

--- a/src/main/java/com/archyx/aureliumskills/util/file/FileUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/file/FileUtil.java
@@ -1,13 +1,11 @@
 package com.archyx.aureliumskills.util.file;
 
 import com.archyx.aureliumskills.util.math.NumberUtil;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 
 public class FileUtil {
 
-    @Nullable
     public static String renameNoDuplicates(File file, String resultName, File directory) {
         // Count duplicates
         int duplicates = 0;

--- a/src/main/java/com/archyx/aureliumskills/util/item/ItemUtils.java
+++ b/src/main/java/com/archyx/aureliumskills/util/item/ItemUtils.java
@@ -74,7 +74,9 @@ public class ItemUtils {
 	}
 
 	public static NBTCompound getModifiersTypeCompound(NBTItem item, ModifierType type) {
-		return getCompound(getModifiersCompound(item), TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT)));
+		String name = TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT));
+		assert (null != name);
+		return getCompound(getModifiersCompound(item), name);
 	}
 
 	public static NBTCompound getRequirementsCompound(NBTItem item) {
@@ -82,7 +84,9 @@ public class ItemUtils {
 	}
 
 	public static NBTCompound getRequirementsTypeCompound(NBTItem item, ModifierType type) {
-		return getCompound(getRequirementsCompound(item), TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT)));
+		String name = TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT));
+		assert (null != name);
+		return getCompound(getRequirementsCompound(item), name);
 	}
 
 	public static NBTCompound getMultipliersCompound(NBTItem item) {
@@ -90,7 +94,9 @@ public class ItemUtils {
 	}
 
 	public static NBTCompound getMultipliersTypeCompound(NBTItem item, ModifierType type) {
-		return getCompound(getMultipliersCompound(item), TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT)));
+		String name = TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT));
+		assert (null != name);
+		return getCompound(getMultipliersCompound(item), name);
 	}
 
 	public static void removeParentCompounds(NBTCompound compound) {

--- a/src/main/java/com/archyx/aureliumskills/util/item/ItemUtils.java
+++ b/src/main/java/com/archyx/aureliumskills/util/item/ItemUtils.java
@@ -9,7 +9,6 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -74,9 +73,7 @@ public class ItemUtils {
 	}
 
 	public static NBTCompound getModifiersTypeCompound(NBTItem item, ModifierType type) {
-		String name = TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT));
-		assert (null != name);
-		return getCompound(getModifiersCompound(item), name);
+		return getCompound(getModifiersCompound(item), TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT)));
 	}
 
 	public static NBTCompound getRequirementsCompound(NBTItem item) {
@@ -84,9 +81,7 @@ public class ItemUtils {
 	}
 
 	public static NBTCompound getRequirementsTypeCompound(NBTItem item, ModifierType type) {
-		String name = TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT));
-		assert (null != name);
-		return getCompound(getRequirementsCompound(item), name);
+		return getCompound(getRequirementsCompound(item), TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT)));
 	}
 
 	public static NBTCompound getMultipliersCompound(NBTItem item) {
@@ -94,9 +89,7 @@ public class ItemUtils {
 	}
 
 	public static NBTCompound getMultipliersTypeCompound(NBTItem item, ModifierType type) {
-		String name = TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT));
-		assert (null != name);
-		return getCompound(getMultipliersCompound(item), name);
+		return getCompound(getMultipliersCompound(item), TextUtil.capitalize(type.name().toLowerCase(Locale.ROOT)));
 	}
 
 	public static void removeParentCompounds(NBTCompound compound) {
@@ -121,7 +114,6 @@ public class ItemUtils {
 		return true;
 	}
 
-	@Nullable
 	public static ItemStack addItemToInventory(Player player, ItemStack item) {
 		PlayerInventory inventory = player.getInventory();
 		int amountRemaining = item.getAmount();
@@ -176,8 +168,6 @@ public class ItemUtils {
 		return amountRemaining <= 0;
 	}
 
-
-	@Nullable
 	public static ItemStack parseItem(String name) {
 		Material material = Material.getMaterial(name);
 		if (material != null) {

--- a/src/main/java/com/archyx/aureliumskills/util/item/MaterialUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/item/MaterialUtil.java
@@ -2,13 +2,11 @@ package com.archyx.aureliumskills.util.item;
 
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.Material;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
 public class MaterialUtil {
 
-    @Nullable
     public static Material parse(String name) {
         Material material = Material.getMaterial(name);
         if (material != null) {

--- a/src/main/java/com/archyx/aureliumskills/util/math/RomanNumber.java
+++ b/src/main/java/com/archyx/aureliumskills/util/math/RomanNumber.java
@@ -48,7 +48,9 @@ public class RomanNumber {
 	    	if (OptionL.getBoolean(Option.ENABLE_ROMAN_NUMERALS)) {
 		        int l =  map.floorKey(number);
 		        if ( number == l ) {
-		            return map.get(number);
+		            String roman = map.get(number);
+		            assert (null != roman);
+		            return roman;
 		        }
 		        return map.get(l) + toRoman(number-l);
 	    	}

--- a/src/main/java/com/archyx/aureliumskills/util/misc/DataUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/misc/DataUtil.java
@@ -10,6 +10,7 @@ public class DataUtil {
         // Check if not null
         Object object = map.get(key);
         Validate.notNull(object, "Reward/loot requires entry with key " + key);
+        assert (null != object);
         return object;
     }
 

--- a/src/main/java/com/archyx/aureliumskills/util/misc/DataUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/misc/DataUtil.java
@@ -3,14 +3,14 @@ package com.archyx.aureliumskills.util.misc;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class DataUtil {
 
     public static Object getElement(Map<?, ?> map, String key) {
         // Check if not null
         Object object = map.get(key);
-        Validate.notNull(object, "Reward/loot requires entry with key " + key);
-        assert (null != object);
+        Objects.requireNonNull(object, "Reward/loot requires entry with key " + key);
         return object;
     }
 

--- a/src/main/java/com/archyx/aureliumskills/util/text/TextUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/text/TextUtil.java
@@ -77,7 +77,8 @@ public class TextUtil {
         if (strLen == 0) {
             return str;
         }
-
+        assert (null != str);
+        
         final int firstCodepoint = str.codePointAt(0);
         final int newCodePoint = Character.toTitleCase(firstCodepoint);
         if (firstCodepoint == newCodePoint) {

--- a/src/main/java/com/archyx/aureliumskills/util/text/TextUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/text/TextUtil.java
@@ -2,14 +2,15 @@ package com.archyx.aureliumskills.util.text;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class TextUtil {
 
     public static String replace(String source, String os, String ns) {
-        if (source == null) {
-            return null;
-        }
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(os);
+        Objects.requireNonNull(ns);
         int i = 0;
         if ((i = source.indexOf(os, i)) >= 0) {
             char[] sourceArray = source.toCharArray();
@@ -53,12 +54,17 @@ public class TextUtil {
     }
 
     public static String replaceNonEscaped(String source, String os, String ns) {
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(os);
+        Objects.requireNonNull(ns);
         String replaced = replace(source, "\\" + os, "\uE000"); // Replace escaped characters with intermediate char
         replaced = replace(replaced, os, ns); // Replace normal chars
         return replace(replaced, "\uE000", os); // Replace intermediate with original
     }
 
-    public static String removeEnd(final String str, final String remove) {
+    public static String removeEnd(String str, String remove) {
+        Objects.requireNonNull(str);
+        Objects.requireNonNull(remove);
         if (isEmpty(str) || isEmpty(remove)) {
             return str;
         }
@@ -68,58 +74,55 @@ public class TextUtil {
         return str;
     }
 
-    public static boolean isEmpty(final CharSequence cs) {
+    public static boolean isEmpty(CharSequence cs) {
         return cs == null || cs.length() == 0;
     }
 
-    public static String capitalize(final String str) {
-        final int strLen = length(str);
+    public static String capitalize(String str) {
+        Objects.requireNonNull(str);
+        int strLen = length(str);
         if (strLen == 0) {
             return str;
         }
-        assert (null != str);
         
-        final int firstCodepoint = str.codePointAt(0);
-        final int newCodePoint = Character.toTitleCase(firstCodepoint);
+        int firstCodepoint = str.codePointAt(0);
+        int newCodePoint = Character.toTitleCase(firstCodepoint);
         if (firstCodepoint == newCodePoint) {
             // already capitalized
             return str;
         }
 
-        final int[] newCodePoints = new int[strLen]; // cannot be longer than the char array
+        int[] newCodePoints = new int[strLen]; // cannot be longer than the char array
         int outOffset = 0;
         newCodePoints[outOffset++] = newCodePoint; // copy the first codepoint
         for (int inOffset = Character.charCount(firstCodepoint); inOffset < strLen; ) {
-            final int codepoint = str.codePointAt(inOffset);
+            int codepoint = str.codePointAt(inOffset);
             newCodePoints[outOffset++] = codepoint; // copy the remaining ones
             inOffset += Character.charCount(codepoint);
         }
         return new String(newCodePoints, 0, outOffset);
     }
 
-    public static int length(final CharSequence cs) {
+    public static int length(CharSequence cs) {
         return cs == null ? 0 : cs.length();
     }
 
-    public static String repeat(final char ch, final int repeat) {
+    public static String repeat(char ch, int repeat) {
         if (repeat <= 0) {
             return "";
         }
-        final char[] buf = new char[repeat];
+        char[] buf = new char[repeat];
         Arrays.fill(buf, ch);
         return new String(buf);
     }
 
 
-    public static String repeat(final String str, final int repeat) {
-        // Performance tuned for 2.0 (JDK1.4)
-        if (str == null) {
-            return null;
-        }
+    public static String repeat(String str, int repeat) {
+        Objects.requireNonNull(str);
         if (repeat <= 0) {
             return "";
         }
-        final int inputLength = str.length();
+        int inputLength = str.length();
         if (repeat == 1 || inputLength == 0) {
             return str;
         }
@@ -127,21 +130,21 @@ public class TextUtil {
             return repeat(str.charAt(0), repeat);
         }
 
-        final int outputLength = inputLength * repeat;
+        int outputLength = inputLength * repeat;
         switch (inputLength) {
             case 1 :
                 return repeat(str.charAt(0), repeat);
             case 2 :
-                final char ch0 = str.charAt(0);
-                final char ch1 = str.charAt(1);
-                final char[] output2 = new char[outputLength];
+                char ch0 = str.charAt(0);
+                char ch1 = str.charAt(1);
+                char[] output2 = new char[outputLength];
                 for (int i = repeat * 2 - 2; i >= 0; i--, i--) {
                     output2[i] = ch0;
                     output2[i + 1] = ch1;
                 }
                 return new String(output2);
             default :
-                final StringBuilder buf = new StringBuilder(outputLength);
+                StringBuilder buf = new StringBuilder(outputLength);
                 for (int i = 0; i < repeat; i++) {
                     buf.append(str);
                 }
@@ -149,13 +152,10 @@ public class TextUtil {
         }
     }
 
-    private static Set<Integer> generateDelimiterSet(final char[] delimiters) {
-        final Set<Integer> delimiterHashSet = new HashSet<>();
-        if (delimiters == null || delimiters.length == 0) {
-            if (delimiters == null) {
-                delimiterHashSet.add(Character.codePointAt(new char[] {' '}, 0));
-            }
-
+    private static Set<Integer> generateDelimiterSet(char [] delimiters) {
+        Objects.requireNonNull(delimiters);
+        Set<Integer> delimiterHashSet = new HashSet<>();
+        if (delimiters.length == 0) {
             return delimiterHashSet;
         }
 
@@ -165,25 +165,27 @@ public class TextUtil {
         return delimiterHashSet;
     }
 
-    public static String capitalizeWord(final String str, final char... delimiters) {
+    public static String capitalizeWord(String str, char ... delimiters) {
+        Objects.requireNonNull(str);
+        Objects.requireNonNull(delimiters);
         if (isEmpty(str)) {
             return str;
         }
-        final Set<Integer> delimiterSet = generateDelimiterSet(delimiters);
-        final int strLen = str.length();
-        final int[] newCodePoints = new int[strLen];
+        Set<Integer> delimiterSet = generateDelimiterSet(delimiters);
+        int strLen = str.length();
+        int[] newCodePoints = new int[strLen];
         int outOffset = 0;
 
         boolean capitalizeNext = true;
         for (int index = 0; index < strLen;) {
-            final int codePoint = str.codePointAt(index);
+            int codePoint = str.codePointAt(index);
 
             if (delimiterSet.contains(codePoint)) {
                 capitalizeNext = true;
                 newCodePoints[outOffset++] = codePoint;
                 index += Character.charCount(codePoint);
             } else if (capitalizeNext) {
-                final int titleCaseCodePoint = Character.toTitleCase(codePoint);
+                int titleCaseCodePoint = Character.toTitleCase(codePoint);
                 newCodePoints[outOffset++] = titleCaseCodePoint;
                 index += Character.charCount(titleCaseCodePoint);
                 capitalizeNext = false;
@@ -195,8 +197,9 @@ public class TextUtil {
         return new String(newCodePoints, 0, outOffset);
     }
 
-    public static String capitalizeWord(final String str) {
-        return capitalizeWord(str, null);
+    public static String capitalizeWord(String str) {
+        Objects.requireNonNull(str);
+        return capitalizeWord(str, ' ');
     }
 
 

--- a/src/main/java/com/archyx/aureliumskills/util/text/TextUtil.java
+++ b/src/main/java/com/archyx/aureliumskills/util/text/TextUtil.java
@@ -152,7 +152,7 @@ public class TextUtil {
         }
     }
 
-    private static Set<Integer> generateDelimiterSet(char [] delimiters) {
+    private static Set<Integer> generateDelimiterSet(char[] delimiters) {
         Objects.requireNonNull(delimiters);
         Set<Integer> delimiterHashSet = new HashSet<>();
         if (delimiters.length == 0) {

--- a/src/main/java/com/archyx/aureliumskills/util/version/VersionUtils.java
+++ b/src/main/java/com/archyx/aureliumskills/util/version/VersionUtils.java
@@ -4,7 +4,6 @@ import com.archyx.aureliumskills.util.math.NumberUtil;
 import com.cryptomorin.xseries.XMaterial;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
-import org.jetbrains.annotations.Nullable;
 
 public class VersionUtils {
 
@@ -44,7 +43,7 @@ public class VersionUtils {
         return 0;
     }
 
-    public static String getVersionString(@Nullable String version) {
+    public static String getVersionString(String version) {
         if (version == null || version.equals("")) {
             return null;
         }
@@ -58,8 +57,6 @@ public class VersionUtils {
             index = version.indexOf('-');
             version = version.substring(0, index);
         }
-
-        assert (null != version);
 
         version = version.split(" ")[0]; // Remove extra words
 

--- a/src/main/java/com/archyx/aureliumskills/util/version/VersionUtils.java
+++ b/src/main/java/com/archyx/aureliumskills/util/version/VersionUtils.java
@@ -59,6 +59,8 @@ public class VersionUtils {
             version = version.substring(0, index);
         }
 
+        assert (null != version);
+
         version = version.split(" ")[0]; // Remove extra words
 
         return version;

--- a/src/main/java/com/archyx/aureliumskills/util/world/WorldManager.java
+++ b/src/main/java/com/archyx/aureliumskills/util/world/WorldManager.java
@@ -46,6 +46,8 @@ public class WorldManager {
             return false;
         }
         World world = location.getWorld();
+        if (world == null)
+            return false;
         return disabledWorlds.contains(world.getName()) || blockedWorlds.contains(world.getName());
     }
 
@@ -54,6 +56,8 @@ public class WorldManager {
             return false;
         }
         World world = location.getWorld();
+        if (world == null)
+            return false;
         return disabledWorlds.contains(world.getName());
     }
 
@@ -62,6 +66,8 @@ public class WorldManager {
             return false;
         }
         World world = location.getWorld();
+        if (world == null)
+            return false;
         return blockedCheckBlockReplaceWorlds.contains(world.getName());
     }
 


### PR DESCRIPTION
Comprehensive analysis of Aurelium Skills for null pointer exceptions, including NPE bugs fixes that were found as a result.

There are still lots of instances of unsafe access where assumptions have been made using string literals; TextUtil methods, which both accepts and returns null values; Locale, the resulting default language, and translations, ActiveMenu properties, and possibly others. 

Assertions have been added for all instances of unsafe access, where certain behavior is assumed. Search of 'assert (null !=' for all instances of unsafe behavior that should be refactored.

This commit makes no changes in functional behavior to the plugin, and is meant to address potential null access violations, as well as to assert on undefined behavior. This is also a precursor to a full null analysis annotations commit of the source tree. Because the complete annotation will modify a lot of files I decided to split the pull request into two parts; one for the patches which address the problems found through analysis (without the annotations), and a second pull request with the annotations added. This also helps make it easier to debug any regressions in the event that I made an error.
