### PR TITLE
Fixed "Retrieval"-Ability detecting tridents as arrows

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/archery/ArcheryAbilities.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/archery/ArcheryAbilities.java
@@ -165,6 +165,7 @@ public class ArcheryAbilities extends AbilityImpl {
         // Ignore if an entity was hit
         if (event.getHitBlock() == null || event.getHitEntity() != null) return;
         if (!(event.getEntity() instanceof AbstractArrow arrow)) return;
+        if (event.getEntity() instanceof Trident) return;
         if (arrow.getPickupStatus() != PickupStatus.ALLOWED) return;
         if (!(arrow.getShooter() instanceof Player player)) return;
 


### PR DESCRIPTION
As stated in this [support-request](https://discord.com/channels/732657582313046027/1224006285570216117), the "Retrieval"-Ability would also allow tridents to get retrieved as arrows which it shouldn't.