### PR TITLE
Remove saplings and every TreeType when they grow from placed blocks

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/region/BukkitRegionManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/region/BukkitRegionManager.java
@@ -60,7 +60,7 @@ public class BukkitRegionManager extends RegionManager {
         chunkData.addPlacedBlock(new BlockPosition(block.getX(), block.getY(), block.getZ()));
     }
 
-    public void removePlacedBlock(Block block) {;
+    public void removePlacedBlock(Block block) {
         Region region = getRegionFromBlock(block);
         if (region != null) {
             byte regionChunkX = (byte) (block.getChunk().getX() - region.getX() * 32);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/region/RegionBlockListener.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/region/RegionBlockListener.java
@@ -11,6 +11,7 @@ import dev.aurelium.auraskills.common.util.data.Pair;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -20,6 +21,7 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -132,6 +134,13 @@ public class RegionBlockListener implements Listener {
             }
         }
         regionManager.removePlacedBlock(lastBlock);
+    }
+
+    @EventHandler
+    public void onStructureGrow(StructureGrowEvent event) {
+        for(BlockState state : event.getBlocks()) {
+            regionManager.removePlacedBlock(state.getBlock());
+        }
     }
 
     private void checkTallPlant(Block block, int num, Predicate<Material> isMaterial) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/region/RegionBlockListener.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/region/RegionBlockListener.java
@@ -138,7 +138,11 @@ public class RegionBlockListener implements Listener {
 
     @EventHandler
     public void onStructureGrow(StructureGrowEvent event) {
-        for(BlockState state : event.getBlocks()) {
+        int growY = event.getLocation().getBlockY();
+        for (BlockState state : event.getBlocks()) {
+            // Only remove placed blocks at same y level as sapling
+            if (state.getLocation().getY() != growY) continue;
+
             regionManager.removePlacedBlock(state.getBlock());
         }
     }


### PR DESCRIPTION
Fixes #243

This will remove the placed sapling/mushroom and everything from the [TreeType](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/TreeType.html) enum from the placed blocks when they grow naturally or via bonemeal, so placed blocks that are converted into natural blocks can give skill XP.