### PR TITLE
MythicMobs Hook

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
     maven("https://jitpack.io")
     maven("https://repo.dmulloy2.net/repository/public/")
     maven("https://repo.maven.apache.org/maven2/")
+    maven("https://mvn.lumine.io/repository/maven-public/")
 }
 
 dependencies {
@@ -42,6 +43,7 @@ dependencies {
     compileOnly("com.github.TownyAdvanced:Towny:0.98.3.6")
     compileOnly("com.github.Slimefun:Slimefun4:RC-37")
     compileOnly("com.mojang:authlib:1.5.25")
+    compileOnly("io.lumine:Mythic-Dist:5.6.1")
 }
 
 tasks.withType<ShadowJar> {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/Hooks.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/Hooks.java
@@ -1,5 +1,6 @@
 package dev.aurelium.auraskills.bukkit.hooks;
 
+import dev.aurelium.auraskills.bukkit.hooks.mythicmobs.MythicMobsHook;
 import dev.aurelium.auraskills.common.hooks.Hook;
 import dev.aurelium.auraskills.common.hooks.LuckPermsHook;
 
@@ -13,7 +14,8 @@ public enum Hooks {
     SLIMEFUN(SlimefunHook.class, "Slimefun"),
     TOWNY(TownyHook.class, "Towny"),
     VAULT(VaultHook.class, "Vault"),
-    WORLD_GUARD(WorldGuardHook.class, "WorldGuard");
+    WORLD_GUARD(WorldGuardHook.class, "WorldGuard"),
+    MYTHIC_MOBS(MythicMobsHook.class, "MythicMobs");
 
     private final Class<? extends Hook> hookClass;
     private final String pluginName;

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/GiveSkillXpMechanic.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/GiveSkillXpMechanic.java
@@ -11,6 +11,7 @@ import io.lumine.mythic.api.skills.placeholders.PlaceholderDouble;
 import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+import org.bukkit.Bukkit;
 
 @MythicMechanic(name = "giveSkillXP")
 public class GiveSkillXpMechanic implements ITargetedEntitySkill {
@@ -32,7 +33,9 @@ public class GiveSkillXpMechanic implements ITargetedEntitySkill {
         var player = BukkitAdapter.adapt(target.asPlayer());
         var user = plugin.getUser(player);
 
-        plugin.getLevelManager().addXp(user, skill, null, xp.get(data));
+        Bukkit.getScheduler().runTask(plugin,
+                () -> plugin.getLevelManager().addXp(user, skill, null, xp.get(data)));
+
 
         return SkillResult.SUCCESS;
     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/GiveSkillXpMechanic.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/GiveSkillXpMechanic.java
@@ -1,0 +1,39 @@
+package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
+
+import dev.aurelium.auraskills.api.registry.NamespacedId;
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.api.skills.placeholders.PlaceholderDouble;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+
+@MythicMechanic(name = "giveSkillXP")
+public class GiveSkillXpMechanic implements ITargetedEntitySkill {
+    private final AuraSkills plugin;
+    private final PlaceholderDouble xp;
+    private final Skill skill;
+
+    public GiveSkillXpMechanic(AuraSkills plugin, MythicMechanicLoadEvent loader) {
+        this.plugin = plugin;
+        this.xp = loader.getConfig().getPlaceholderDouble("xp", 0.0D);
+        this.skill = plugin.getSkillRegistry().get(NamespacedId.fromDefault(loader.getConfig().getString(new String[]{"skill", "s"})));
+    }
+
+    @Override
+    public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
+        if (!target.isPlayer()) return SkillResult.INVALID_TARGET;
+        if (skill == null) return SkillResult.INVALID_CONFIG;
+
+        var player = BukkitAdapter.adapt(target.asPlayer());
+        var user = plugin.getUser(player);
+
+        plugin.getLevelManager().addXp(user, skill, null, xp.get(data));
+
+        return SkillResult.SUCCESS;
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/HasManaCondition.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/HasManaCondition.java
@@ -1,22 +1,25 @@
 package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
 
-import dev.aurelium.auraskills.api.AuraSkillsApi;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
 import io.lumine.mythic.api.skills.SkillCaster;
 import io.lumine.mythic.api.skills.conditions.ICasterCondition;
+import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
 import io.lumine.mythic.core.utils.annotations.MythicCondition;
 
 @MythicCondition(name = "hasMana")
 public class HasManaCondition implements ICasterCondition {
+    private final AuraSkills plugin;
     private final double requiredMana;
 
-    public HasManaCondition(MythicConditionLoadEvent loader) {
-        this.requiredMana = loader.getConfig().getDouble(new String[] { "mana", "m" }, 0);
+    public HasManaCondition(AuraSkills plugin, MythicConditionLoadEvent loader) {
+        this.plugin = plugin;
+        this.requiredMana = loader.getConfig().getDouble(new String[]{"mana", "m"}, 0);
     }
 
     @Override
     public boolean check(SkillCaster caster) {
-        if(!caster.getEntity().isPlayer()) return false;
-        return AuraSkillsApi.get().getUser(caster.getEntity().getUniqueId()).getMana() >= requiredMana;
+        if (!caster.getEntity().isPlayer()) return false;
+        return plugin.getUser(BukkitAdapter.adapt(caster.getEntity().asPlayer())).getMana() >= requiredMana;
     }
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/HasManaCondition.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/HasManaCondition.java
@@ -1,0 +1,22 @@
+package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
+
+import dev.aurelium.auraskills.api.AuraSkillsApi;
+import io.lumine.mythic.api.skills.SkillCaster;
+import io.lumine.mythic.api.skills.conditions.ICasterCondition;
+import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
+import io.lumine.mythic.core.utils.annotations.MythicCondition;
+
+@MythicCondition(name = "hasMana")
+public class HasManaCondition implements ICasterCondition {
+    private final double requiredMana;
+
+    public HasManaCondition(MythicConditionLoadEvent loader) {
+        this.requiredMana = loader.getConfig().getDouble(new String[] { "mana", "m" }, 0);
+    }
+
+    @Override
+    public boolean check(SkillCaster caster) {
+        if(!caster.getEntity().isPlayer()) return false;
+        return AuraSkillsApi.get().getUser(caster.getEntity().getUniqueId()).getMana() >= requiredMana;
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
@@ -18,6 +18,7 @@ import dev.aurelium.auraskills.common.modifier.DamageModifier;
 import dev.aurelium.auraskills.common.user.User;
 import dev.aurelium.auraskills.common.util.mechanics.DamageType;
 import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.MythicBukkit;
 import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
 import io.lumine.mythic.bukkit.events.MythicDamageEvent;
 import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
@@ -151,6 +152,11 @@ public class MythicMobsHook extends Hook implements Listener {
                 event.setDamage(fakeEvent.getDamage());
             }
         }
+    }
+
+    public boolean shouldPreventEntityXp(Entity entity) {
+        if(!getConfig().node("prevent_regular_xp").getBoolean()) return false;
+        return MythicBukkit.inst().getMobManager().isMythicMob(entity);
     }
 
     @EventHandler

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
@@ -1,0 +1,113 @@
+package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
+
+import dev.aurelium.auraskills.api.trait.Traits;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.bukkit.skills.defense.DefenseAbilities;
+import dev.aurelium.auraskills.bukkit.skills.fighting.FightingAbilities;
+import dev.aurelium.auraskills.bukkit.trait.AttackDamageTrait;
+import dev.aurelium.auraskills.bukkit.trait.DamageReductionTrait;
+import dev.aurelium.auraskills.common.AuraSkillsPlugin;
+import dev.aurelium.auraskills.common.hooks.Hook;
+import dev.aurelium.auraskills.common.modifier.DamageModifier;
+import dev.aurelium.auraskills.common.user.User;
+import dev.aurelium.auraskills.common.util.mechanics.DamageType;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
+import io.lumine.mythic.bukkit.events.MythicDamageEvent;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.spongepowered.configurate.ConfigurationNode;
+
+public class MythicMobsHook extends Hook implements Listener {
+    public MythicMobsHook(AuraSkillsPlugin plugin, ConfigurationNode config) {
+        super(plugin, config);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onMythicSkillDamage(MythicDamageEvent event) {
+        // This is always some sort of skill damage.
+
+        var damager = event.getCaster().getEntity();
+        var target = event.getTarget();
+
+
+        // We don't need to apply strength here.
+        // Seems like it is already working fine.
+
+        if (target.isPlayer()) {
+            var playerTarget = BukkitAdapter.adapt(target.asPlayer());
+            if (plugin.getWorldManager().isDisabledWorld(playerTarget.getWorld().getName())) {
+                return;
+            }
+            User user = plugin.getUserManager().getUser(playerTarget.getUniqueId());
+
+
+            var plugin = (AuraSkills) this.plugin;
+
+            // we don't need to handle absorption, since it cancels the entire event ahead of time
+
+            var fakeEvent = new EntityDamageByEntityEvent(damager.getBukkitEntity(), target.getBukkitEntity(), event.getDamageMetadata().getDamageCause(), null, event.getDamage());
+
+            // Handles parry
+            if (getConfig().node("handle-fighting-abilities").getBoolean()) {
+                FightingAbilities fightingAbilities = plugin.getAbilityManager().getAbilityImpl(FightingAbilities.class);
+                fightingAbilities.handleParry(fakeEvent, playerTarget, user);
+                event.setDamage(fakeEvent.getDamage());
+            }
+
+            if (getConfig().node("handle-damage-reduction").getBoolean()) {
+                // Handles damage reduction trait
+                var damageReduction = plugin.getTraitManager().getTraitImpl(DamageReductionTrait.class);
+                damageReduction.onDamage(fakeEvent, user);
+
+                DefenseAbilities defenseAbilities = plugin.getAbilityManager().getAbilityImpl(DefenseAbilities.class);
+
+                // Handles mob master
+                defenseAbilities.mobMaster(fakeEvent, user, playerTarget);
+
+                // Handles shielding
+                defenseAbilities.shielding(fakeEvent, user, playerTarget);
+
+                event.setDamage(fakeEvent.getDamage());
+            }
+        }
+
+    }
+
+    @EventHandler
+    public void onMechanicLoad(MythicMechanicLoadEvent e) {
+        if(e.getMechanicName().equalsIgnoreCase("takeMana")) {
+            e.register(new TakeManaMechanic(e));
+        }
+    }
+
+    @EventHandler
+    public void onConditionLoad(MythicConditionLoadEvent e) {
+        if(e.getConditionName().equalsIgnoreCase("hasMana")) {
+            e.register(new HasManaCondition(e));
+        }
+    }
+
+    private double applyModifier(MythicDamageEvent event, DamageModifier modifier) {
+        switch (modifier.operation()) {
+            case MULTIPLY -> {
+                double multiplier = 1.0 + modifier.value();
+                event.setDamage(event.getDamage() * multiplier);
+            }
+            case ADD_BASE -> event.setDamage(event.getDamage() + modifier.value());
+            case ADD_COMBINED -> {
+                return modifier.value();
+            }
+        }
+        return 0.0;
+    }
+
+    @Override
+    public Class<? extends Hook> getTypeClass() {
+        return MythicMobsHook.class;
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
@@ -1,12 +1,18 @@
 package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
 
-import dev.aurelium.auraskills.api.trait.Traits;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.bukkit.listeners.CriticalHandler;
+import dev.aurelium.auraskills.bukkit.skills.archery.ArcheryAbilities;
 import dev.aurelium.auraskills.bukkit.skills.defense.DefenseAbilities;
+import dev.aurelium.auraskills.bukkit.skills.excavation.ExcavationAbilities;
+import dev.aurelium.auraskills.bukkit.skills.farming.FarmingAbilities;
 import dev.aurelium.auraskills.bukkit.skills.fighting.FightingAbilities;
+import dev.aurelium.auraskills.bukkit.skills.foraging.ForagingAbilities;
+import dev.aurelium.auraskills.bukkit.skills.mining.MiningAbilities;
 import dev.aurelium.auraskills.bukkit.trait.AttackDamageTrait;
 import dev.aurelium.auraskills.bukkit.trait.DamageReductionTrait;
-import dev.aurelium.auraskills.common.AuraSkillsPlugin;
+import dev.aurelium.auraskills.bukkit.util.VersionUtils;
+import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.hooks.Hook;
 import dev.aurelium.auraskills.common.modifier.DamageModifier;
 import dev.aurelium.auraskills.common.user.User;
@@ -15,51 +21,121 @@ import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.events.MythicConditionLoadEvent;
 import io.lumine.mythic.bukkit.events.MythicDamageEvent;
 import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
-import org.bukkit.entity.Player;
+import org.bukkit.Material;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.spongepowered.configurate.ConfigurationNode;
 
+import java.lang.reflect.Constructor;
+
 public class MythicMobsHook extends Hook implements Listener {
-    public MythicMobsHook(AuraSkillsPlugin plugin, ConfigurationNode config) {
+    private final AuraSkills plugin;
+    private final CriticalHandler criticalHandler;
+
+    public MythicMobsHook(AuraSkills plugin, ConfigurationNode config) {
         super(plugin, config);
+        this.plugin = plugin;
+        this.criticalHandler = new CriticalHandler(plugin);
     }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onMythicSkillDamage(MythicDamageEvent event) {
-        // This is always some sort of skill damage.
+        // This is always some sort of skill/mechanic damage.
+
+        if (!getConfig().node("handle_fighting_abilities").getBoolean() &&
+                !getConfig().node("handle_damage_reduction").getBoolean()) {
+            return;
+        }
 
         var damager = event.getCaster().getEntity();
         var target = event.getTarget();
+        var fakeEvent = createDamageEvent(damager.getBukkitEntity(), target.getBukkitEntity(), event.getDamageMetadata().getDamageCause(), event.getDamage());
 
+        // If the damager is a player, server probably has MythicCrucible addon, that let you use
+        // mechanics/skills on weapons.
+        if (damager.isPlayer() && getConfig().node("handle_fighting_abilities").getBoolean()) {
+            var player = BukkitAdapter.adapt(damager.asPlayer());
+            if (player.hasMetadata("NPC")) return;
+            if (event.getDamageMetadata().getDamageCause() == EntityDamageEvent.DamageCause.THORNS) return;
 
-        // We don't need to apply strength here.
-        // Seems like it is already working fine.
+            User user = plugin.getUser(player);
 
+            DamageType damageType = getDamageType(player);
+            var additive = 0;
+
+            var attackDamage = plugin.getTraitManager().getTraitImpl(AttackDamageTrait.class);
+
+            DamageModifier strengthMod = attackDamage.strength(user, damageType);
+            additive += applyModifier(event, strengthMod);
+
+            // Apply master abilities
+            var abManager = plugin.getAbilityManager();
+            switch (damageType) {
+                case SWORD -> {
+                    DamageModifier mod = abManager.getAbilityImpl(FightingAbilities.class).swordMaster(player, user);
+                    additive += applyModifier(event, mod);
+                }
+                case BOW -> {
+                    DamageModifier mod = abManager.getAbilityImpl(ArcheryAbilities.class).bowMaster(player, user);
+                    additive += applyModifier(event, mod);
+                }
+                case HOE -> {
+                    DamageModifier mod = abManager.getAbilityImpl(FarmingAbilities.class).scytheMaster(player, user);
+                    additive += applyModifier(event, mod);
+                }
+                case AXE -> {
+                    DamageModifier mod = abManager.getAbilityImpl(ForagingAbilities.class).axeMaster(player, user);
+                    additive += applyModifier(event, mod);
+                }
+                case PICKAXE -> {
+                    DamageModifier mod = abManager.getAbilityImpl(MiningAbilities.class).pickMaster(player, user);
+                    additive += applyModifier(event, mod);
+                }
+                case SHOVEL -> {
+                    DamageModifier mod = abManager.getAbilityImpl(ExcavationAbilities.class).spadeMaster(player, user);
+                    additive += applyModifier(event, mod);
+                }
+            }
+
+            // First strike is impossible to activate here
+
+            // Apply critical
+            if (plugin.configBoolean(Option.valueOf("CRITICAL_ENABLED_" + damageType.name()))) {
+                DamageModifier mod = criticalHandler.getCrit(player, user);
+                additive += applyModifier(event, mod);
+            }
+
+            // Charged shot is probably impossible to activate here, or it is probably impossible to make it work
+            // as it supposed to
+
+            // Apply additive (ADD_COMBINED) operation
+            fakeEvent.setDamage(event.getDamage() * (1 + additive));
+            event.setDamage(event.getDamage() * (1 + additive));
+        }
+
+        // Handles being damaged
         if (target.isPlayer()) {
             var playerTarget = BukkitAdapter.adapt(target.asPlayer());
             if (plugin.getWorldManager().isDisabledWorld(playerTarget.getWorld().getName())) {
                 return;
             }
-            User user = plugin.getUserManager().getUser(playerTarget.getUniqueId());
 
-
-            var plugin = (AuraSkills) this.plugin;
+            User user = plugin.getUser(playerTarget);
 
             // we don't need to handle absorption, since it cancels the entire event ahead of time
 
-            var fakeEvent = new EntityDamageByEntityEvent(damager.getBukkitEntity(), target.getBukkitEntity(), event.getDamageMetadata().getDamageCause(), null, event.getDamage());
-
             // Handles parry
-            if (getConfig().node("handle-fighting-abilities").getBoolean()) {
+            if (getConfig().node("handle_fighting_abilities").getBoolean()) {
                 FightingAbilities fightingAbilities = plugin.getAbilityManager().getAbilityImpl(FightingAbilities.class);
                 fightingAbilities.handleParry(fakeEvent, playerTarget, user);
                 event.setDamage(fakeEvent.getDamage());
             }
 
-            if (getConfig().node("handle-damage-reduction").getBoolean()) {
+            if (getConfig().node("handle_damage_reduction").getBoolean()) {
                 // Handles damage reduction trait
                 var damageReduction = plugin.getTraitManager().getTraitImpl(DamageReductionTrait.class);
                 damageReduction.onDamage(fakeEvent, user);
@@ -75,20 +151,21 @@ public class MythicMobsHook extends Hook implements Listener {
                 event.setDamage(fakeEvent.getDamage());
             }
         }
-
     }
 
     @EventHandler
-    public void onMechanicLoad(MythicMechanicLoadEvent e) {
-        if(e.getMechanicName().equalsIgnoreCase("takeMana")) {
-            e.register(new TakeManaMechanic(e));
+    public void onMechanicLoad(MythicMechanicLoadEvent event) {
+        if (event.getMechanicName().equalsIgnoreCase("takeMana")) {
+            event.register(new TakeManaMechanic(plugin, event));
+        } else if (event.getMechanicName().equalsIgnoreCase("giveSkillXP")) {
+            event.register(new GiveSkillXpMechanic(plugin, event));
         }
     }
 
     @EventHandler
-    public void onConditionLoad(MythicConditionLoadEvent e) {
-        if(e.getConditionName().equalsIgnoreCase("hasMana")) {
-            e.register(new HasManaCondition(e));
+    public void onConditionLoad(MythicConditionLoadEvent event) {
+        if (event.getConditionName().equalsIgnoreCase("hasMana")) {
+            event.register(new HasManaCondition(plugin, event));
         }
     }
 
@@ -109,5 +186,51 @@ public class MythicMobsHook extends Hook implements Listener {
     @Override
     public Class<? extends Hook> getTypeClass() {
         return MythicMobsHook.class;
+    }
+
+    public EntityDamageByEntityEvent createDamageEvent(Entity damager, Entity damagee, EntityDamageEvent.DamageCause cause, double damage) {
+        // This constructor only exists in 1.20.4+ but damageSource builder is experimental API
+        // Right now it works with a simple null
+        if (VersionUtils.isAtLeastVersion(20, 4)) {
+            return new EntityDamageByEntityEvent(damager, damagee, cause, null, damage);
+        }
+
+        // This constructor is marked for removal. Use reflection to prevent future issues in code.
+        // This way we can support older version than 1.20.4
+        try {
+            Class<?> clazz = Class.forName("org.bukkit.event.entity.EntityDamageByEntityEvent");
+            Constructor<?> constructor = clazz.getConstructor(Entity.class, Entity.class, EntityDamageEvent.DamageCause.class, double.class);
+            Object eventInstance = constructor.newInstance(damager, damagee, cause, damage);
+
+            return (EntityDamageByEntityEvent) eventInstance;
+        } catch (Exception e) {
+            plugin.logger().warn("MythicMobs hook tried to create an EntityDamageByEntityEvent with a constructor that is not supported in this server version. Please report this.");
+        }
+        return null;
+    }
+
+    private DamageType getDamageType(Player player) {
+        // With MythicDamageEvent we don't know if a projectile/trident is involved but
+        // for the most part is doesn't really matter. Only thing that matters if what item was
+        // used when the skill/mechanic was cast.
+        // There can be edge cases if someone puts a damage mechanic on the armor for example
+        // with the ~onDamaged trigger, although this is unlikely.
+        Material material = player.getInventory().getItemInMainHand().getType();
+        if (material.name().contains("SWORD")) {
+            return DamageType.SWORD;
+        } else if (material.name().contains("_AXE")) {
+            return DamageType.AXE;
+        } else if (material.name().contains("PICKAXE")) {
+            return DamageType.PICKAXE;
+        } else if (material.name().contains("SHOVEL") || material.name().contains("SPADE")) {
+            return DamageType.SHOVEL;
+        } else if (material.name().contains("HOE")) {
+            return DamageType.HOE;
+        } else if (material.equals(Material.AIR)) {
+            return DamageType.HAND;
+        } else if (material.equals(Material.BOW) || material.equals(Material.TRIDENT)) {
+            return DamageType.BOW;
+        }
+        return DamageType.OTHER;
     }
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/TakeManaMechanic.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/TakeManaMechanic.java
@@ -1,30 +1,32 @@
 package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
 
-import dev.aurelium.auraskills.api.AuraSkillsApi;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
 import io.lumine.mythic.api.skills.SkillMetadata;
 import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 import io.lumine.mythic.core.utils.annotations.MythicMechanic;
 
 @MythicMechanic(name = "takeMana")
 public class TakeManaMechanic implements ITargetedEntitySkill {
 
+    private final AuraSkills plugin;
     private final double manaToTake;
 
-    public TakeManaMechanic(MythicMechanicLoadEvent loader) {
-        this.manaToTake = loader.getConfig().getDouble(new String[] {"mana", "m"}, 0);
+    public TakeManaMechanic(AuraSkills plugin, MythicMechanicLoadEvent loader) {
+        this.plugin = plugin;
+        this.manaToTake = loader.getConfig().getDouble(new String[]{"mana", "m"}, 0);
     }
 
     @Override
     public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
-        if(!data.getCaster().getEntity().isPlayer()) return SkillResult.CONDITION_FAILED;
+        if (!data.getCaster().getEntity().isPlayer()) return SkillResult.CONDITION_FAILED;
 
-        var user = AuraSkillsApi.get().getUser(data.getCaster().getEntity().getUniqueId());
+        var user = plugin.getUser(BukkitAdapter.adapt(data.getCaster().getEntity().asPlayer()));
 
-        if(user == null) return SkillResult.CONDITION_FAILED;
-        if(user.getMana() < manaToTake) return SkillResult.CONDITION_FAILED;
+        if (user.getMana() < manaToTake) return SkillResult.CONDITION_FAILED;
 
         user.setMana(user.getMana() - manaToTake);
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/TakeManaMechanic.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/TakeManaMechanic.java
@@ -1,0 +1,33 @@
+package dev.aurelium.auraskills.bukkit.hooks.mythicmobs;
+
+import dev.aurelium.auraskills.api.AuraSkillsApi;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import io.lumine.mythic.core.utils.annotations.MythicMechanic;
+
+@MythicMechanic(name = "takeMana")
+public class TakeManaMechanic implements ITargetedEntitySkill {
+
+    private final double manaToTake;
+
+    public TakeManaMechanic(MythicMechanicLoadEvent loader) {
+        this.manaToTake = loader.getConfig().getDouble(new String[] {"mana", "m"}, 0);
+    }
+
+    @Override
+    public SkillResult castAtEntity(SkillMetadata data, AbstractEntity target) {
+        if(!data.getCaster().getEntity().isPlayer()) return SkillResult.CONDITION_FAILED;
+
+        var user = AuraSkillsApi.get().getUser(data.getCaster().getEntity().getUniqueId());
+
+        if(user == null) return SkillResult.CONDITION_FAILED;
+        if(user.getMana() < manaToTake) return SkillResult.CONDITION_FAILED;
+
+        user.setMana(user.getMana() - manaToTake);
+
+        return SkillResult.SUCCESS;
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/EntityLeveler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/EntityLeveler.java
@@ -7,6 +7,8 @@ import dev.aurelium.auraskills.api.source.type.EntityXpSource;
 import dev.aurelium.auraskills.api.source.type.EntityXpSource.EntityDamagers;
 import dev.aurelium.auraskills.api.source.type.EntityXpSource.EntityTriggers;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.bukkit.hooks.Hooks;
+import dev.aurelium.auraskills.bukkit.hooks.mythicmobs.MythicMobsHook;
 import dev.aurelium.auraskills.bukkit.skills.fighting.FightingAbilities;
 import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.source.SourceTypes;
@@ -42,6 +44,13 @@ public class EntityLeveler extends SourceLeveler {
     public void onEntityDeath(EntityDeathEvent event) {
         if (disabled()) return;
         LivingEntity entity = event.getEntity();
+
+        if(plugin.getHookManager().isRegistered(MythicMobsHook.class)) {
+            if(plugin.getHookManager().getHook(MythicMobsHook.class).shouldPreventEntityXp(entity)) {
+                return;
+            }
+        }
+
         // Ensure that the entity has a killer
         @Nullable
         Player player = entity.getKiller();
@@ -85,6 +94,13 @@ public class EntityLeveler extends SourceLeveler {
         if (!(event.getEntity() instanceof LivingEntity entity) || event.getEntity() instanceof ArmorStand) {
             return;
         }
+
+        if(plugin.getHookManager().isRegistered(MythicMobsHook.class)) {
+            if(plugin.getHookManager().getHook(MythicMobsHook.class).shouldPreventEntityXp(entity)) {
+                return;
+            }
+        }
+
         // Get the player who damaged the entity and the damager type
         Pair<Player, EntityXpSource.EntityDamagers> damagerPair = resolveDamager(event.getDamager(), event.getCause());
         if (damagerPair == null) return;
@@ -113,6 +129,12 @@ public class EntityLeveler extends SourceLeveler {
         if (disabled()) return;
         if (!(event.getEntity() instanceof LivingEntity entity) || event.getEntity() instanceof ArmorStand) {
             return;
+        }
+
+        if(plugin.getHookManager().isRegistered(MythicMobsHook.class)) {
+            if(plugin.getHookManager().getHook(MythicMobsHook.class).shouldPreventEntityXp(entity)) {
+                return;
+            }
         }
 
         Player player = getBleedDamager(entity);

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: dev.aurelium.auraskills.bukkit.AuraSkills
 description: The ultra-versatile RPG skills plugin
 author: Archyx
 website: https://aurelium.dev/auraskills
-softdepend: [WorldGuard, PlaceholderAPI, HolographicDisplays, DecentHolograms, Vault, ProtocolLib, LuckPerms, Slimefun, Towny]
+softdepend: [WorldGuard, PlaceholderAPI, HolographicDisplays, DecentHolograms, Vault, ProtocolLib, LuckPerms, Slimefun, Towny, MythicMobs]
 api-version: '1.13'
 prefix: AuraSkills
 

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -46,8 +46,8 @@ hooks:
       - 'Example'
   MythicMobs:
     enabled: true
-    handle-fighting-abilities: true
-    handle-damage-reduction: true
+    handle_fighting_abilities: true
+    handle_damage_reduction: true
 action_bar:
   enabled: true
   idle: true

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -48,6 +48,7 @@ hooks:
     enabled: true
     handle_fighting_abilities: true
     handle_damage_reduction: true
+    prevent_regular_xp: false
 action_bar:
   enabled: true
   idle: true

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -44,6 +44,10 @@ hooks:
       - 'Example'
     blocked_check_replace_regions:
       - 'Example'
+  MythicMobs:
+    enabled: true
+    handle-fighting-abilities: true
+    handle-damage-reduction: true
 action_bar:
   enabled: true
   idle: true


### PR DESCRIPTION
This PR tries to properly apply AuraSkills skill/ability/stat modifiers to Mythic damage mechanics while also adding some new conditions, mechanics and configuration.

### Here is how it works:
1. Mythic damage mechanic runs
2. It creates an EntityDamageByEntityEvent and calls it
3. The default listener in AuraSkills can't do too much, because mythic will override it on HIGHEST priority
4. Before that override Mythic calls MythicDamageEvent with the default mechanic damage
5. We modify this damage so it has the proper effect (using a fake created EntityDamageByEntityEvent so we don't need to rewrite internals)
6. After that, Mythic will still apply its [modifiers](https://git.mythiccraft.io/mythiccraft/MythicMobs/-/wikis/Mobs/DamageModifiers). I think this is correct behavior.

### New Mythic Conditions
There is a new condition `hasMana{m=number}` which you can use if you have MythicCrucible for item skills.
eg.: `message{m="hello world"} ~onUse ?hasMana{m=490}`
It checks if the player has the required amount of mana. If not, then the mechanic/skill is cancelled

### New Mythic Mechanics
There are 2 new added mythic mechanics. `takeMana` and `giveSkillXP`

**takeMana**
Takes mana from the player when the player casts the skill/mechanic on an item.
eg.: `takeMana{m=20} ~onAttack ?hasMana{m=490}`
It should usually be combined with `hasMana`. If the player has the required amount of mana, take the mana and do some skill/mechanic.

**giveSkillXP**
Gives skill xp to the player.
eg. as a mob skill: `giveSkillXP{xp=100;s=fighting} @trigger ~onDeath`
Here it will give skill xp to the player who triggered the mobs death.
The `xp` parameter can be a math formula with Mythic placeholders and PAPI placeholders (if you have Mythic Premium)
The `s` parameter can be written as `skill`. It should support every skill not just the builtin ones.

### Mythic Hook Config

```yaml
  MythicMobs:
    enabled: true
    # Apply fighting abilities damage modifiers on MythicDamageEvent
    handle_fighting_abilities: true
    # Apply damage reduction modifiers and defense abilities on MythicDamageEvent
    handle_damage_reduction: true
    # If true, EntityLeveler won't give XP for MythicMobs
    prevent_regular_xp: false
```

**NOTE** It seems like config.yml is not updating with these new values by default. Can I call some internal thing to do that or what should I do?