### PR TITLE
Jobs update

### DIFF
--- a/api/src/main/java/dev/aurelium/auraskills/api/source/CustomSource.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/CustomSource.java
@@ -55,6 +55,11 @@ public class CustomSource implements XpSource {
         return values.getXp();
     }
 
+    @Override
+    public SourceIncome getIncome() {
+        return values.getIncome();
+    }
+
     public SourceValues getValues() {
         return values;
     }

--- a/api/src/main/java/dev/aurelium/auraskills/api/source/SourceContext.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/SourceContext.java
@@ -29,7 +29,8 @@ public class SourceContext extends BaseContext {
         double xp = source.node("xp").getDouble(0.0);
         @Nullable String displayName = source.node("display_name").getString();
         @Nullable String unitName = source.node("unit_name").getString();
-        return new SourceValues(api, sourceType, id, xp, displayName, unitName);
+        SourceIncome income = api.getSourceManager().loadSourceIncome(source);
+        return new SourceValues(api, sourceType, id, xp, displayName, unitName, income);
     }
 
 }

--- a/api/src/main/java/dev/aurelium/auraskills/api/source/SourceIncome.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/SourceIncome.java
@@ -1,0 +1,19 @@
+package dev.aurelium.auraskills.api.source;
+
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.api.user.SkillsUser;
+
+public interface SourceIncome {
+
+    /**
+     * Gets the money income earned from gaining the XP source.
+     *
+     * @param user         the user gaining XP
+     * @param sourceValues the source value data
+     * @param skill        the skill the user is gaining XP in
+     * @param finalXp      the final XP gained by the user after multipliers
+     * @return the income earned
+     */
+    double getIncomeEarned(SkillsUser user, SourceValues sourceValues, Skill skill, double finalXp);
+
+}

--- a/api/src/main/java/dev/aurelium/auraskills/api/source/SourceManager.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/SourceManager.java
@@ -1,7 +1,9 @@
 package dev.aurelium.auraskills.api.source;
 
+import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
 
 import java.util.List;
 import java.util.Locale;
@@ -32,5 +34,8 @@ public interface SourceManager {
 
     @Nullable
     String getUnitName(XpSource source, Locale locale);
+
+    @Internal
+    SourceIncome loadSourceIncome(ConfigurationNode source);
 
 }

--- a/api/src/main/java/dev/aurelium/auraskills/api/source/SourceValues.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/SourceValues.java
@@ -14,15 +14,17 @@ public class SourceValues {
     private final String displayName;
     @Nullable
     private final String unitName;
+    private final SourceIncome income;
 
     public SourceValues(AuraSkillsApi api, SourceType type, NamespacedId id, double xp,
-                        @Nullable String displayName, @Nullable String unitName) {
+                        @Nullable String displayName, @Nullable String unitName, SourceIncome income) {
         this.api = api;
         this.type = type;
         this.id = id;
         this.xp = xp;
         this.displayName = displayName;
         this.unitName = unitName;
+        this.income = income;
     }
 
     public AuraSkillsApi getApi() {
@@ -49,5 +51,9 @@ public class SourceValues {
     @Nullable
     public String getUnitName() {
         return unitName;
+    }
+
+    public SourceIncome getIncome() {
+        return income;
     }
 }

--- a/api/src/main/java/dev/aurelium/auraskills/api/source/XpSource.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/XpSource.java
@@ -45,6 +45,22 @@ public interface XpSource {
     double getXp();
 
     /**
+     * Gets the income data for this source that determines the money gained
+     * when the source is gained. Income is only gained if jobs are enabled.
+     *
+     * @return the source income data
+     */
+    SourceIncome getIncome();
+
+    /**
+     * Gets the {@link SourceValues} object that contains data about the source. All the information
+     * in the source values is already accessible through other methods in this interface.
+     *
+     * @return the source values
+     */
+    SourceValues getValues();
+
+    /**
      * Checks if the XP source is valid on the server's Minecraft version.
      *
      * @return whether the XP source is valid

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
@@ -21,6 +21,7 @@ import dev.aurelium.auraskills.bukkit.event.BukkitEventHandler;
 import dev.aurelium.auraskills.bukkit.hooks.WorldGuardFlags;
 import dev.aurelium.auraskills.bukkit.item.ApiItemManager;
 import dev.aurelium.auraskills.bukkit.item.BukkitItemRegistry;
+import dev.aurelium.auraskills.bukkit.jobs.JobsListener;
 import dev.aurelium.auraskills.bukkit.level.BukkitLevelManager;
 import dev.aurelium.auraskills.bukkit.listeners.CriticalHandler;
 import dev.aurelium.auraskills.bukkit.listeners.DamageListener;
@@ -396,6 +397,7 @@ public class AuraSkills extends JavaPlugin implements AuraSkillsPlugin {
         pm.registerEvents(new RegionListener(this), this);
         pm.registerEvents(new RegionBlockListener(this), this);
         pm.registerEvents(new PlayerDeath(this), this);
+        pm.registerEvents(new JobsListener(this), this);
     }
 
     public BukkitAudiences getAudiences() {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
@@ -348,6 +348,7 @@ public class AuraSkills extends JavaPlugin implements AuraSkillsPlugin {
     private void generateDefaultMenuFiles() {
         menuFileManager = new MenuFileManager(this);
         menuFileManager.generateDefaultFiles();
+        menuFileManager.updateMenus();
     }
 
     private void initializeMenus() {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/config/BukkitConfigProvider.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/config/BukkitConfigProvider.java
@@ -4,6 +4,7 @@ import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.bukkit.hooks.HookRegistrar;
 import dev.aurelium.auraskills.common.config.*;
+import dev.aurelium.auraskills.common.hooks.EconomyHook;
 import dev.aurelium.auraskills.common.message.PlatformLogger;
 import dev.aurelium.auraskills.common.skill.LoadedSkill;
 import org.bukkit.ChatColor;
@@ -149,6 +150,8 @@ public class BukkitConfigProvider implements ConfigProvider {
 
     @Override
     public boolean jobSelectionEnabled() {
-        return plugin.configBoolean(Option.JOBS_ENABLED) && plugin.configBoolean(Option.JOBS_SELECTION_REQUIRE_SELECTION);
+        boolean economyEnabled = plugin.getHookManager().isRegistered(EconomyHook.class);
+        boolean selectionEnabled = plugin.configBoolean(Option.JOBS_SELECTION_REQUIRE_SELECTION);
+        return plugin.configBoolean(Option.JOBS_ENABLED) && economyEnabled && selectionEnabled;
     }
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/config/BukkitConfigProvider.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/config/BukkitConfigProvider.java
@@ -146,4 +146,9 @@ public class BukkitConfigProvider implements ConfigProvider {
     public int getStartLevel() {
         return options.get(Option.START_LEVEL).asInt();
     }
+
+    @Override
+    public boolean jobSelectionEnabled() {
+        return plugin.configBoolean(Option.JOBS_ENABLED) && plugin.configBoolean(Option.JOBS_SELECTION_REQUIRE_SELECTION);
+    }
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/jobs/JobsListener.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/jobs/JobsListener.java
@@ -1,0 +1,33 @@
+package dev.aurelium.auraskills.bukkit.jobs;
+
+import dev.aurelium.auraskills.api.event.skill.XpGainEvent;
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.common.config.Option;
+import dev.aurelium.auraskills.common.user.User;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class JobsListener implements Listener {
+
+    private final AuraSkills plugin;
+
+    public JobsListener(AuraSkills plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void blockXpGain(XpGainEvent event) {
+        if (!plugin.config().jobSelectionEnabled()) return;
+        if (!plugin.configBoolean(Option.JOBS_SELECTION_DISABLE_UNSELECTED_XP)) return;
+
+        Skill skill = event.getSkill();
+        User user = plugin.getUser(event.getPlayer());
+
+        if (!user.getJobs().contains(skill)) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/BukkitLevelManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/BukkitLevelManager.java
@@ -82,7 +82,7 @@ public class BukkitLevelManager extends LevelManager {
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) return;
 
-        addXpRaw(user, skill, event.getAmount());
+        addXpRaw(user, skill, event.getAmount(), source);
     }
 
     public void addDamageXp(User user, Skill skill, @NotNull XpSource source, double amount,
@@ -95,7 +95,7 @@ public class BukkitLevelManager extends LevelManager {
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) return;
 
-        addXpRaw(user, skill, event.getAmount());
+        addXpRaw(user, skill, event.getAmount(), source);
     }
 
     @Override

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/LevelProgressionMenu.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/LevelProgressionMenu.java
@@ -12,7 +12,6 @@ import dev.aurelium.auraskills.bukkit.menus.shared.GlobalItems;
 import dev.aurelium.auraskills.bukkit.menus.shared.SkillItem;
 import dev.aurelium.auraskills.bukkit.menus.shared.SkillLevelItem;
 import dev.aurelium.auraskills.common.ability.AbilityUtil;
-import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.reward.SkillReward;
 import dev.aurelium.auraskills.common.reward.type.MoneyReward;
 import dev.aurelium.auraskills.common.user.User;
@@ -144,7 +143,7 @@ public class LevelProgressionMenu {
         menu.item("job", item -> {
             item.replace("skill", p -> ((Skill) p.menu().getProperty("skill")).getDisplayName(p.locale(), false));
             // Hide if jobs are disabled
-            item.modify(i -> plugin.configBoolean(Option.JOBS_ENABLED) ? i.item() : null);
+            item.modify(i -> plugin.config().jobSelectionEnabled() ? i.item() : null);
 
             item.onClick(ClickTrigger.LEFT, c -> {
                 User user = plugin.getUserManager().getUser(c.player());

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/LevelProgressionMenu.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/LevelProgressionMenu.java
@@ -12,10 +12,13 @@ import dev.aurelium.auraskills.bukkit.menus.shared.GlobalItems;
 import dev.aurelium.auraskills.bukkit.menus.shared.SkillItem;
 import dev.aurelium.auraskills.bukkit.menus.shared.SkillLevelItem;
 import dev.aurelium.auraskills.common.ability.AbilityUtil;
+import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.reward.SkillReward;
 import dev.aurelium.auraskills.common.reward.type.MoneyReward;
+import dev.aurelium.auraskills.common.user.User;
 import dev.aurelium.auraskills.common.util.math.RomanNumber;
 import dev.aurelium.auraskills.common.util.text.TextUtil;
+import dev.aurelium.slate.action.trigger.ClickTrigger;
 import dev.aurelium.slate.builder.BuiltMenu;
 import dev.aurelium.slate.builder.MenuBuilder;
 import dev.aurelium.slate.info.ComponentPlaceholderInfo;
@@ -137,6 +140,59 @@ public class LevelProgressionMenu {
                 return hasEnabledAbility ? i.item() : null;
             });
         });
+
+        menu.item("job", item -> {
+            item.replace("skill", p -> ((Skill) p.menu().getProperty("skill")).getDisplayName(p.locale(), false));
+            // Hide if jobs are disabled
+            item.modify(i -> plugin.configBoolean(Option.JOBS_ENABLED) ? i.item() : null);
+
+            item.onClick(ClickTrigger.LEFT, c -> {
+                User user = plugin.getUserManager().getUser(c.player());
+                Skill skill = (Skill) c.menu().getProperty("skill");
+                // Select as job
+                if (!user.getJobs().contains(skill) && user.getJobs().size() < user.getJobLimit()) {
+                    user.addJob(skill);
+                    c.menu().reload();
+                    c.menu().setCooldown("job", 10);
+                }
+            });
+
+            item.onClick(ClickTrigger.RIGHT, c -> {
+                User user = plugin.getUserManager().getUser(c.player());
+                Skill skill = (Skill) c.menu().getProperty("skill");
+                // Quit job
+                if (user.getJobs().contains(skill)) {
+                    user.removeJob(skill);
+                    c.menu().reload();
+                    c.menu().setCooldown("job", 10);
+                }
+            });
+        });
+
+        menu.component("job_select", null, component -> {
+            component.replace("skill", p -> ((Skill) p.menu().getProperty("skill")).getDisplayName(p.locale(), false));
+
+            component.shouldShow(t -> {
+                User user = plugin.getUser(t.player());
+                Skill skill = (Skill) t.menu().getProperty("skill");
+                // User isn't working job and can add this job
+                return !user.getJobs().contains(skill) && user.getJobs().size() < user.getJobLimit();
+            });
+        });
+
+        menu.component("job_active", null, component -> component.shouldShow(t -> {
+            User user = plugin.getUser(t.player());
+            Skill skill = (Skill) t.menu().getProperty("skill");
+            // User is working this job
+            return user.getJobs().contains(skill);
+        }));
+
+        menu.component("job_limit", null, component -> component.shouldShow(t -> {
+            User user = plugin.getUser(t.player());
+            Skill skill = (Skill) t.menu().getProperty("skill");
+            // User isn't working this job and cannot add this job
+            return !user.getJobs().contains(skill) && user.getJobs().size() >= user.getJobLimit();
+        }));
 
         menu.template("skill", Skill.class, template -> {
             // Sets text replacements and modifier

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/MenuFileManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/MenuFileManager.java
@@ -3,8 +3,14 @@ package dev.aurelium.auraskills.bukkit.menus;
 import dev.aurelium.auraskills.api.registry.NamespacedRegistry;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.common.api.ApiAuraSkills;
+import dev.aurelium.auraskills.common.util.file.FileUtil;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.yaml.NodeStyle;
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
 
 import java.io.File;
+import java.io.IOException;
 
 public class MenuFileManager {
 
@@ -34,4 +40,83 @@ public class MenuFileManager {
         int menusLoaded = plugin.getSlate().loadMenus();
         plugin.getLogger().info("Loaded " + menusLoaded + " menus");
     }
+
+    public void updateMenus() {
+        for (String menuName : MENU_NAMES) {
+            File userFile = new File(plugin.getDataFolder() + "/menus", menuName + ".yml");
+            if (!userFile.exists()) continue;
+
+            try {
+                ConfigurationNode embeddedConfig = FileUtil.loadEmbeddedYamlFile("menus/" + menuName + ".yml", plugin);
+                ConfigurationNode userConfig = FileUtil.loadYamlFile(userFile);
+
+                updateAndSave(embeddedConfig, userConfig, userFile);
+            } catch (IOException e) {
+                plugin.logger().warn("Error updating menu file " + userFile.getName());
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void updateAndSave(ConfigurationNode embedded, ConfigurationNode user, File userFile) throws SerializationException {
+        int changed = 0;
+        changed += updateConfigSection("items", embedded, user);
+        changed += updateConfigSection("templates", embedded, user);
+        changed += updateConfigSection("components", embedded, user);
+        changed += updateStringSection("formats", embedded, user);
+
+        if (changed <= 0) {
+            return;
+        }
+        try {
+            YamlConfigurationLoader loader = YamlConfigurationLoader.builder()
+                    .file(userFile)
+                    .nodeStyle(NodeStyle.BLOCK)
+                    .indent(2)
+                    .build();
+            loader.save(user);
+
+            plugin.logger().info("Menu file " + userFile.getName() + " was updated: " + changed + " new sections added");
+        } catch (IOException e) {
+            plugin.logger().warn("Error saving menu file " + userFile.getName());
+            e.printStackTrace();
+        }
+    }
+
+    private int updateConfigSection(String name, ConfigurationNode embedded, ConfigurationNode user) throws SerializationException {
+        int changed = 0;
+        if (!embedded.node(name).virtual() && !user.node(name).virtual()) {
+            for (ConfigurationNode embSec : embedded.node(name).childrenMap().values()) {
+                String key = (String) embSec.key();
+                if (key == null) continue;
+                if (!embSec.isMap()) continue;
+                // User file does not have embedded key
+                if (user.node(name).node(key).virtual()) {
+                    user.node(name).node(key).set(embSec);
+                    changed++;
+                }
+            }
+        }
+        return changed;
+    }
+
+    private int updateStringSection(String name, ConfigurationNode embedded, ConfigurationNode user) throws SerializationException {
+        int changed = 0;
+        if (!embedded.node(name).virtual() && !user.node(name).virtual()) {
+            for (ConfigurationNode embSec : embedded.node(name).childrenMap().values()) {
+                String key = (String) embSec.key();
+                if (key == null) continue;
+
+                String value = embSec.getString();
+                if (value == null) continue;
+                // User file does not have embedded key
+                if (user.node(name).node(key).virtual()) {
+                    user.node(name).node(key).set(value);
+                    changed++;
+                }
+            }
+        }
+        return changed;
+    }
+
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/MenuFileUpdates.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/MenuFileUpdates.java
@@ -1,0 +1,52 @@
+package dev.aurelium.auraskills.bukkit.menus;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public enum MenuFileUpdates {
+
+    SKILLS_1("skills", 1, Map.of(
+            "components", List.of("skill_job_active"))),
+    LEVEL_PROGRESSION_1("level_progression", 1, Map.of(
+            "items", List.of("job"),
+            "components", List.of("job_select", "job_active", "job_limit")));
+
+    private final String menu;
+    private final int version;
+    private final Map<String, List<String>> addedKeys;
+
+    MenuFileUpdates(String menu, int version, Map<String, List<String>> addedKeys) {
+        this.menu = menu;
+        this.version = version;
+        this.addedKeys = addedKeys;
+    }
+
+    public String getMenu() {
+        return menu;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public Map<String, List<String>> getAddedKeys() {
+        return addedKeys;
+    }
+
+    public static List<MenuFileUpdates> getUpdates(String menu, int currentVersion, int updatedVersion) {
+        List<MenuFileUpdates> updates = new ArrayList<>();
+        for (MenuFileUpdates update : MenuFileUpdates.values()) {
+            if (!update.getMenu().equals(menu)) continue;
+
+            if (update.getVersion() > currentVersion && update.getVersion() <= updatedVersion) {
+                updates.add(update);
+            }
+        }
+        // Sort by increasing version
+        updates.sort(Comparator.comparingInt(MenuFileUpdates::getVersion));
+        return updates;
+    }
+
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/shared/SkillItem.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/shared/SkillItem.java
@@ -100,9 +100,8 @@ public class SkillItem {
     }
 
     private void skillJobActive(MenuBuilder menu) {
-        menu.component("skill_job_active", Skill.class, component -> {
-            component.shouldShow(t -> plugin.config().jobSelectionEnabled() && plugin.getUser(t.player()).getJobs().contains(t.value()));
-        });
+        menu.component("skill_job_active", Skill.class, component ->
+                component.shouldShow(t -> plugin.config().jobSelectionEnabled() && plugin.getUser(t.player()).getJobs().contains(t.value())));
     }
 
     public void statsLeveled(MenuBuilder menu) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/shared/SkillItem.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/shared/SkillItem.java
@@ -18,8 +18,13 @@ import dev.aurelium.auraskills.common.util.text.Replacer;
 import dev.aurelium.auraskills.common.util.text.TextUtil;
 import dev.aurelium.slate.builder.MenuBuilder;
 import dev.aurelium.slate.builder.TemplateBuilder;
+import dev.aurelium.slate.info.TemplateInfo;
 import dev.aurelium.slate.item.provider.ListBuilder;
 import dev.aurelium.slate.menu.LoadedMenu;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.spongepowered.configurate.serialize.SerializationException;
 
 import java.util.List;
@@ -48,17 +53,36 @@ public class SkillItem {
 
         template.modify(t -> {
             if (!t.value().isEnabled()) return null;
+            ItemStack item = t.item();
             if (t.value() instanceof CustomSkill customSkill) {
                 try { // Get custom skill API-defined item
                     ConfigurateItemParser parser = new ConfigurateItemParser(plugin);
-                    return parser.parseBaseItem(parser.parseItemContext(customSkill.getDefined().getItem()));
+                    item = parser.parseBaseItem(parser.parseItemContext(customSkill.getDefined().getItem()));
                 } catch (SerializationException | IllegalArgumentException e) {
                     plugin.logger().warn("Error parsing ItemContext of CustomSkill " + customSkill.getId());
                     e.printStackTrace();
                 }
             }
-            return t.item();
+            addSelectedJobGlint(item, t);
+            return item;
         });
+    }
+
+    private void addSelectedJobGlint(ItemStack item, TemplateInfo<Skill> t) {
+        if (!t.menu().getName().equals("skills")) return; // Don't apply to level progression menu
+        if (!plugin.config().jobSelectionEnabled()) return;
+
+        // Show enchant glint if selected as job
+        User user = plugin.getUser(t.player());
+        Skill skill = t.value();
+        if (user.getJobs().contains(skill)) {
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.addEnchant(Enchantment.MENDING, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                item.setItemMeta(meta);
+            }
+        }
     }
 
     /**
@@ -72,6 +96,13 @@ public class SkillItem {
         manaAbilityInfo(menu);
         progress(menu);
         maxLevel(menu);
+        skillJobActive(menu);
+    }
+
+    private void skillJobActive(MenuBuilder menu) {
+        menu.component("skill_job_active", Skill.class, component -> {
+            component.shouldShow(t -> plugin.config().jobSelectionEnabled() && plugin.getUser(t.player()).getJobs().contains(t.value()));
+        });
     }
 
     public void statsLeveled(MenuBuilder menu) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BukkitUiProvider.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BukkitUiProvider.java
@@ -15,6 +15,7 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 
+import java.text.NumberFormat;
 import java.time.Duration;
 
 public class BukkitUiProvider implements UiProvider {
@@ -36,6 +37,15 @@ public class BukkitUiProvider implements UiProvider {
         return actionBarManager;
     }
 
+    @Override
+    public NumberFormat getFormat(FormatType type) {
+        return switch (type) {
+            case XP -> bossBarManager.getXpFormat();
+            case PERCENT -> bossBarManager.getPercentFormat();
+            case MONEY -> bossBarManager.getMoneyFormat();
+        };
+    }
+
     public BossBarManager getBossBarManager() {
         return bossBarManager;
     }
@@ -55,10 +65,10 @@ public class BukkitUiProvider implements UiProvider {
     }
 
     @Override
-    public void sendXpBossBar(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed) {
+    public void sendXpBossBar(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed, double income) {
         Player player = ((BukkitUser) user).getPlayer();
         if (player == null) return;
-        bossBarManager.sendBossBar(player, skill, currentXp, levelXp, xpGained, level, maxed);
+        bossBarManager.sendBossBar(player, skill, currentXp, levelXp, xpGained, level, maxed, income);
     }
 
     @Override

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/user/BukkitUser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/user/BukkitUser.java
@@ -140,6 +140,32 @@ public class BukkitUser extends User {
     }
 
     @Override
+    public int getPermissionJobLimit() {
+        if (player == null) return 0;
+
+        final String prefix = "auraskills.jobs.limit.";
+        int highestLimit = 0;
+
+        for (PermissionAttachmentInfo permissionInfo : player.getEffectivePermissions()) {
+            String permission = permissionInfo.getPermission();
+
+            if (!permission.startsWith(prefix)) continue;
+
+            permission = permission.substring(prefix.length());
+
+            if (isNumeric(permission)) {
+                try {
+                    int value = Integer.parseInt(permission);
+                    if (value > highestLimit) {
+                        highestLimit = value;
+                    }
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+        return highestLimit;
+    }
+
+    @Override
     public void sendMessage(Component component) {
         // Don't send empty messages
         if (plugin.getMessageProvider().componentToString(component).isEmpty()) {

--- a/bukkit/src/main/resources/menus/level_progression.yml
+++ b/bukkit/src/main/resources/menus/level_progression.yml
@@ -65,6 +65,18 @@ items:
           3: '<light_purple>'
       - ' '
       - '<yellow>{{abilities_click}}'
+  job:
+    pos: 0,4
+    material: gold_ingot
+    display_name: '<yellow>{{job}}'
+    lore:
+      - text: '{{job_desc}}'
+        wrap: true
+        style: '<gray>'
+      - ' '
+      - component: job_select
+      - component: job_active
+      - component: job_limit
 templates:
   skill:
     pos: 0,0
@@ -206,6 +218,19 @@ components:
         styles:
           0: '<gray>'
           1: '<yellow>'
+  job_select:
+    lore:
+      - '<yellow>{{job_select}}'
+  job_active:
+    lore:
+      - '<green>{{job_active}}'
+      - ' '
+      - '<red>{{job_quit}}'
+  job_limit:
+    lore:
+      - text: '{{job_limit}}'
+        wrap: true
+        style: '<red>'
 formats:
   stat_leveled_entry: '{color}{stat}<gray>'
   unlocked_ability_entry: '\n  <gold>{name} {level} <dark_gray>({info})'

--- a/bukkit/src/main/resources/menus/level_progression.yml
+++ b/bukkit/src/main/resources/menus/level_progression.yml
@@ -9,22 +9,22 @@ items:
     material: paper
     display_name: '<gold>{{your_ranking}}'
     lore:
-      - text: '{{rank_out_of}}'
-        styles:
-          1: '<white>'
-          2: '<gold>'
-      - text: '{{rank_percent}}'
-        styles:
-          1: '<white>'
-          2: '<gold>'
-      - ' '
-      - '<yellow>{{leaderboard_click}}'
+    - text: '{{rank_out_of}}'
+      styles:
+        1: '<white>'
+        2: '<gold>'
+    - text: '{{rank_percent}}'
+      styles:
+        1: '<white>'
+        2: '<gold>'
+    - ' '
+    - '<yellow>{{leaderboard_click}}'
   back:
     pos: 5,0
     material: arrow
     display_name: '<green>{{back}}'
     lore:
-      - '<gray>{{back_click}}'
+    - '<gray>{{back_click}}'
   close:
     pos: 5,1
     material: barrier
@@ -34,203 +34,237 @@ items:
     material: arrow
     display_name: '<gold>{{next_page}}'
     lore:
-      - '<yellow>{{next_page_click}}'
+    - '<yellow>{{next_page_click}}'
   previous_page:
     pos: 5,7
     material: arrow
     display_name: '<gold>{{previous_page}}'
     lore:
-      - '<yellow>{{previous_page_click}}'
+    - '<yellow>{{previous_page_click}}'
   sources:
     pos: 0,2
     material: experience_bottle
     display_name: '<green>{{sources}}'
     lore:
-      - text: '{{sources_desc}}'
-        wrap: true
-        style: '<gray>'
-      - ' '
-      - '<yellow>{{sources_click}}'
+    - text: '{{sources_desc}}'
+      wrap: true
+      style: '<gray>'
+    - ' '
+    - '<yellow>{{sources_click}}'
   abilities:
     pos: 0,3
     material: light_blue_dye
     display_name: '<red>{{abilities}}'
     lore:
-      - text: '{{abilities_desc}} {{mana_abilities_desc}}'
-        wrap: true
-        wrap_style: 1
-        styles:
-          1: '<gray>'
-          2: '<aqua>'
-          3: '<light_purple>'
-      - ' '
-      - '<yellow>{{abilities_click}}'
+    - text: '{{abilities_desc}} {{mana_abilities_desc}}'
+      wrap: true
+      wrap_style: 1
+      styles:
+        1: '<gray>'
+        2: '<aqua>'
+        3: '<light_purple>'
+    - ' '
+    - '<yellow>{{abilities_click}}'
   job:
     pos: 0,4
     material: gold_ingot
     display_name: '<yellow>{{job}}'
     lore:
-      - text: '{{job_desc}}'
-        wrap: true
-        style: '<gray>'
-      - ' '
-      - component: job_select
-      - component: job_active
-      - component: job_limit
+    - text: '{{job_desc}}'
+      wrap: true
+      style: '<gray>'
+    - ' '
+    - component: job_select
+    - component: job_active
+    - component: job_limit
 templates:
   skill:
     pos: 0,0
     contexts:
-      farming: {material: diamond_hoe, flags: [hide_attributes]}
-      foraging: {material: stone_axe, flags: [hide_attributes]}
-      mining: {material: iron_pickaxe, flags: [hide_attributes]}
-      fishing: {material: fishing_rod}
-      excavation: {material: golden_shovel, flags: [hide_attributes]}
-      archery: {material: bow}
-      defense: {material: chainmail_chestplate, flags: [hide_attributes]}
-      fighting: {material: diamond_sword, flags: [hide_attributes]}
-      endurance: {material: golden_apple}
-      agility: {material: feather}
-      alchemy: {material: potion, potion_data: {type: instant_heal}, flags: [hide_potion_effects]}
-      enchanting: {material: enchanting_table}
-      sorcery: {material: blaze_rod}
-      healing: {material: splash_potion, potion_data: {type: instant_heal}, flags: [hide_potion_effects]}
-      forging: {material: anvil}
+      farming:
+        material: iron_hoe
+        flags:
+        - hide_attributes
+      foraging:
+        material: iron_axe
+        flags:
+        - hide_attributes
+      mining:
+        material: iron_pickaxe
+        flags:
+        - hide_attributes
+      fishing:
+        material: fishing_rod
+      excavation:
+        material: iron_shovel
+        flags:
+        - hide_attributes
+      archery:
+        material: bow
+      defense:
+        material: chainmail_chestplate
+        flags:
+        - hide_attributes
+      fighting:
+        material: iron_sword
+        flags:
+        - hide_attributes
+      endurance:
+        material: golden_apple
+      agility:
+        material: feather
+      alchemy:
+        material: potion
+        potion_data:
+          type: regen
+        flags:
+        - hide_potion_effects
+      enchanting:
+        material: enchanting_table
+      sorcery:
+        material: blaze_rod
+      healing:
+        material: splash_potion
+        potion_data:
+          type: instant_heal
+        flags: hide_potion_effects
+      forging:
+        material: anvil
     display_name: '<aqua>{skill} <dark_aqua>{level}'
     lore:
-      - text: '{desc}'
-        wrap: true
-        style: '<gray>'
-      - component: stats_leveled
-      - component: ability_levels
-      - component: mana_ability_info
-      - ' '
-      - component: progress
-      - component: max_level
+    - text: '{desc}'
+      wrap: true
+      style: '<gray>'
+    - component: stats_leveled
+    - component: ability_levels
+    - component: mana_ability_info
+    - ' '
+    - component: progress
+    - component: max_level
   unlocked:
     material: lime_stained_glass_pane
     display_name: '<green>{{level}} {level}'
     lore:
-      - '<gray>{{level}} <white>{level}'
-      - component: rewards
-      - component: ability_unlock
-      - component: ability_level
-      - component: mana_ability_unlock
-      - component: mana_ability_level
-      - ' '
-      - '<green>{{unlocked}}'
+    - '<gray>{{level}} <white>{level}'
+    - component: rewards
+    - component: ability_unlock
+    - component: ability_level
+    - component: mana_ability_unlock
+    - component: mana_ability_level
+    - ' '
+    - '<green>{{unlocked}}'
   in_progress:
     material: yellow_stained_glass_pane
     display_name: '<yellow>{{level}} {level}'
     lore:
-      - '<gray>{{level}} <white>{level}'
-      - component: rewards
-      - component: ability_unlock
-      - component: ability_level
-      - component: mana_ability_unlock
-      - component: mana_ability_level
-      - ' '
-      - '<gray>{{progress}}: <yellow>{percent}%'
-      - '{bar}'
-      - '<gray>{current_xp}/{level_xp} {xp_unit}'
-      - ' '
-      - '<yellow>{{in_progress}}'
+    - '<gray>{{level}} <white>{level}'
+    - component: rewards
+    - component: ability_unlock
+    - component: ability_level
+    - component: mana_ability_unlock
+    - component: mana_ability_level
+    - ' '
+    - '<gray>{{progress}}: <yellow>{percent}%'
+    - '{bar}'
+    - '<gray>{current_xp}/{level_xp} {xp_unit}'
+    - ' '
+    - '<yellow>{{in_progress}}'
   locked:
     material: red_stained_glass_pane
     display_name: '<red>{{level}} {level}'
     lore:
-      - '<gray>{{level}} <white>{level}'
-      - component: rewards
-      - component: ability_unlock
-      - component: ability_level
-      - component: mana_ability_unlock
-      - component: mana_ability_level
-      - ' '
-      - '<red>{{locked}}'
+    - '<gray>{{level}} <white>{level}'
+    - component: rewards
+    - component: ability_unlock
+    - component: ability_level
+    - component: mana_ability_unlock
+    - component: mana_ability_level
+    - ' '
+    - '<red>{{locked}}'
 components:
   stats_leveled:
     context: Skill
     lore:
-      - ' '
-      - '<gray>{{stats_leveled}}: {entries[<gray>, ]}'
+    - ' '
+    - '<gray>{{stats_leveled}}: {entries[<gray>, ]}'
   ability_levels:
     context: Skill
     lore:
-      - ' '
-      - '<gray>{{ability_levels}}: {entries[]}'
+    - ' '
+    - '<gray>{{ability_levels}}: {entries[]}'
   mana_ability_info:
     context: Skill
     lore:
-      - ' '
-      - '<light_purple><bold>{{mana_ability}}</bold> <blue>{name} {level}'
-      - '  {entries[\n  ](3)}'
+    - ' '
+    - '<light_purple><bold>{{mana_ability}}</bold> <blue>{name} {level}'
+    - '  {entries[\n  ](3)}'
   progress:
     context: Skill
     lore:
-      - '<gray>{{progress_to_level}} {next_level}: <yellow>{percent}%'
-      - '{bar}'
-      - '<gray>{current_xp}/{level_xp} {xp_unit}'
+    - '<gray>{{progress_to_level}} {next_level}: <yellow>{percent}%'
+    - '{bar}'
+    - '<gray>{current_xp}/{level_xp} {xp_unit}'
   max_level:
     context: Skill
     lore:
-      - '<gold>{{max_level}}'
+    - '<gold>{{max_level}}'
   rewards:
     context: Integer
     lore:
-      - '<gray>{{rewards}}: {entries[]}'
+    - '<gray>{{rewards}}: {entries[]}'
   ability_unlock:
     context: Integer
     lore:
-      - ' '
-      - '<gold>{name} <green><bold>{{ability_unlock}}'
-      - text: '{desc}'
-        wrap: true
-        wrap_indent: '  '
-        style: '<gray>'
+    - ' '
+    - '<gold>{name} <green><bold>{{ability_unlock}}'
+    - text: '{desc}'
+      wrap: true
+      wrap_indent: '  '
+      style: '<gray>'
   ability_level:
     context: Integer
     lore:
-      - ' '
-      - '<gold>{name} {level}'
-      - text: '{desc}'
-        wrap: true
-        wrap_indent: '  '
-        style: '<gray>'
+    - ' '
+    - '<gold>{name} {level}'
+    - text: '{desc}'
+      wrap: true
+      wrap_indent: '  '
+      style: '<gray>'
   mana_ability_unlock:
     context: Integer
     lore:
-      - ' '
-      - '<blue>{name} <light_purple><bold>{{mana_ability_unlock}}'
-      - text: '{desc}'
-        wrap: true
-        wrap_indent: '  '
-        styles:
-          0: '<gray>'
-          1: '<yellow>'
+    - ' '
+    - '<blue>{name} <light_purple><bold>{{mana_ability_unlock}}'
+    - text: '{desc}'
+      wrap: true
+      wrap_indent: '  '
+      styles:
+        0: '<gray>'
+        1: '<yellow>'
   mana_ability_level:
     context: Integer
     lore:
-      - ' '
-      - '<blue>{name} {level}'
-      - text: '{desc}'
-        wrap: true
-        wrap_indent: '  '
-        styles:
-          0: '<gray>'
-          1: '<yellow>'
+    - ' '
+    - '<blue>{name} {level}'
+    - text: '{desc}'
+      wrap: true
+      wrap_indent: '  '
+      styles:
+        0: '<gray>'
+        1: '<yellow>'
   job_select:
     lore:
-      - '<yellow>{{job_select}}'
+    - '<yellow>{{job_select}}'
   job_active:
     lore:
-      - '<green>{{job_active}}'
-      - ' '
-      - '<red>{{job_quit}}'
+    - '<green>{{job_active}}'
+    - ' '
+    - '<red>{{job_quit}}'
   job_limit:
     lore:
-      - text: '{{job_limit}}'
-        wrap: true
-        style: '<red>'
+    - text: '{{job_limit}}'
+      wrap: true
+      style: '<red>'
 formats:
   stat_leveled_entry: '{color}{stat}<gray>'
   unlocked_ability_entry: '\n  <gold>{name} {level} <dark_gray>({info})'
@@ -250,3 +284,4 @@ options:
   items_per_page: 24
   start_level: 1
   track: [9, 18, 27, 36, 37, 38, 29, 20, 11, 12, 13, 22, 31, 40, 41, 42, 33, 24, 15, 16, 17, 26, 35, 44]
+file_version: 1

--- a/bukkit/src/main/resources/menus/skills.yml
+++ b/bukkit/src/main/resources/menus/skills.yml
@@ -75,6 +75,7 @@ templates:
       - ' '
       - component: progress
       - component: max_level
+      - component: skill_job_active
       - ' '
       - '<yellow>{{skill_click}}'
 components:
@@ -104,6 +105,11 @@ components:
     context: Skill
     lore:
       - '<gold>{{max_level}}'
+  skill_job_active:
+    context: Skill
+    lore:
+      - ' '
+      - '<dark_gray>▶ <green>{{active_job}}'
 formats:
   stat_leveled_entry: '{color}{stat}<gray>'
   unlocked_ability_entry: '\n  <gold>{name} {level} <dark_gray>({info})'

--- a/bukkit/src/main/resources/menus/skills.yml
+++ b/bukkit/src/main/resources/menus/skills.yml
@@ -11,16 +11,16 @@ items:
       base64: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjcwNWZkOTRhMGM0MzE5MjdmYjRlNjM5YjBmY2ZiNDk3MTdlNDEyMjg1YTAyYjQzOWUwMTEyZGEyMmIyZTJlYyJ9fX0=
     display_name: '<aqua>{{your_skills}} - <gold>{player}'
     lore:
-      - text: '{{your_skills_desc}}'
-        wrap: true
-        style: '<gray>'
-      - ' '
-      - text: '{{your_skills_hover}}'
-        wrap: true
-        style: '<yellow>'
-      - text: '{{your_skills_click}}'
-        wrap: true
-        style: '<yellow>'
+    - text: '{{your_skills_desc}}'
+      wrap: true
+      style: '<gray>'
+    - ' '
+    - text: '{{your_skills_hover}}'
+      wrap: true
+      style: '<yellow>'
+    - text: '{{your_skills_click}}'
+      wrap: true
+      style: '<yellow>'
   close:
     pos: 4,8
     material: barrier
@@ -30,27 +30,91 @@ items:
     material: player_head
     display_name: '<aqua>{{stats}}'
     lore:
-      - '<gray>{{stats_desc}}'
-      - ' '
-      - '<yellow>{{stats_click}}'
+    - '<gray>{{stats_desc}}'
+    - ' '
+    - '<yellow>{{stats_click}}'
 templates:
   skill:
     contexts:
-      archery: { group: first_row, order: 1, material: bow }
-      fighting: { group: first_row, order: 2, material: iron_sword, flags: [ hide_attributes ] }
-      defense: { group: first_row, order: 3, material: chainmail_chestplate, flags: [ hide_attributes ] }
-      endurance: {group: first_row, order: 4, material: golden_apple}
-      farming: {group: second_row, order: 1, material: iron_hoe, flags: [hide_attributes]}
-      foraging: {group: second_row, order: 2, material: iron_axe, flags: [hide_attributes]}
-      mining: {group: second_row, order: 3, material: iron_pickaxe, flags: [hide_attributes]}
-      fishing: {group: second_row, order: 4, material: fishing_rod}
-      excavation: {group: second_row, order: 5, material: iron_shovel, flags: [hide_attributes]}
-      agility: {group: third_row, order: 1, material: feather}
-      alchemy: {group: third_row, order: 2, material: potion, potion_data: {type: regen}, flags: [hide_potion_effects]}
-      enchanting: {group: third_row, order: 3, material: enchanting_table}
-      sorcery: {group: third_row, order: 4, material: blaze_rod}
-      healing: {group: third_row, order: 5, material: splash_potion, potion_data: {type: instant_heal}, flags: [hide_potion_effects]}
-      forging: {group: third_row, order: 6, material: anvil}
+      archery:
+        group: first_row
+        order: 1
+        material: bow
+      fighting:
+        group: first_row
+        order: 2
+        material: iron_sword
+        flags:
+          - hide_attributes
+      defense:
+        group: first_row
+        order: 3
+        material: chainmail_chestplate
+        flags: hide_attributes
+      endurance:
+        group: first_row
+        order: 4
+        material: golden_apple
+      farming:
+        group: second_row
+        order: 1
+        material: iron_hoe
+        flags:
+          - hide_attributes
+      foraging:
+        group: second_row
+        order: 2
+        material: iron_axe
+        flags:
+          - hide_attributes
+      mining:
+        group: second_row
+        order: 3
+        material: iron_pickaxe
+        flags:
+          - hide_attributes
+      fishing:
+        group: second_row
+        order: 4
+        material: fishing_rod
+      excavation:
+        group: second_row
+        order: 5
+        material: iron_shovel
+        flags:
+          - hide_attributes
+      agility:
+        group: third_row
+        order: 1
+        material: feather
+      alchemy:
+        group: third_row
+        order: 2
+        material: potion
+        potion_data:
+          type: regen
+        flags:
+          - hide_potion_effects
+      enchanting:
+        group: third_row
+        order: 3
+        material: enchanting_table
+      sorcery:
+        group: third_row
+        order: 4
+        material: blaze_rod
+      healing:
+        group: third_row
+        order: 5
+        material: splash_potion
+        potion_data:
+          type: instant_heal
+        flags:
+          - hide_potion_effects
+      forging:
+        group: third_row
+        order: 6
+        material: anvil
     groups:
       first_row:
         start: 1,0
@@ -66,50 +130,50 @@ templates:
         align: center
     display_name: '<aqua>{skill} <dark_aqua>{level}'
     lore:
-      - text: '{desc}'
-        wrap: true
-        style: '<gray>'
-      - component: stats_leveled
-      - component: ability_levels
-      - component: mana_ability_info
-      - ' '
-      - component: progress
-      - component: max_level
-      - component: skill_job_active
-      - ' '
-      - '<yellow>{{skill_click}}'
+    - text: '{desc}'
+      wrap: true
+      style: '<gray>'
+    - component: stats_leveled
+    - component: ability_levels
+    - component: mana_ability_info
+    - ' '
+    - component: progress
+    - component: max_level
+    - component: skill_job_active
+    - ' '
+    - '<yellow>{{skill_click}}'
 components:
   stats_leveled:
     context: Skill
     lore:
-      - ' '
-      - '<gray>{{stats_leveled}}: {entries[<gray>, ]}'
+    - ' '
+    - '<gray>{{stats_leveled}}: {entries[<gray>, ]}'
   ability_levels:
     context: Skill
     lore:
-      - ' '
-      - '<gray>{{ability_levels}}: {entries[]}'
+    - ' '
+    - '<gray>{{ability_levels}}: {entries[]}'
   mana_ability_info:
     context: Skill
     lore:
-      - ' '
-      - '<light_purple><bold>{{mana_ability}}</bold> <blue>{name} {level}'
-      - '  {entries[\n  ](3)}'
+    - ' '
+    - '<light_purple><bold>{{mana_ability}}</bold> <blue>{name} {level}'
+    - '  {entries[\n  ](3)}'
   progress:
     context: Skill
     lore:
-      - '<gray>{{progress_to_level}} {next_level}: <yellow>{percent}%'
-      - '{bar}'
-      - '<gray>{current_xp}/{level_xp} {xp_unit}'
+    - '<gray>{{progress_to_level}} {next_level}: <yellow>{percent}%'
+    - '{bar}'
+    - '<gray>{current_xp}/{level_xp} {xp_unit}'
   max_level:
     context: Skill
     lore:
-      - '<gold>{{max_level}}'
+    - '<gold>{{max_level}}'
   skill_job_active:
     context: Skill
     lore:
-      - ' '
-      - '<dark_gray>▶ <green>{{active_job}}'
+    - ' '
+    - '<dark_gray>▶ <green>{{active_job}}'
 formats:
   stat_leveled_entry: '{color}{stat}<gray>'
   unlocked_ability_entry: '\n  <gold>{name} {level} <dark_gray>({info})'
@@ -126,3 +190,4 @@ formats:
   bar_remaining: '<gray>■'
 options:
   bar_length: 20
+file_version: 1

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -125,3 +125,5 @@ permissions:
         default: true
     auraskills.checkupdates:
         default: op
+    auraskills.jobs.limit:
+        default: false

--- a/common/src/main/java/dev/aurelium/auraskills/common/api/implementation/ApiSourceManager.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/api/implementation/ApiSourceManager.java
@@ -1,14 +1,13 @@
 package dev.aurelium.auraskills.common.api.implementation;
 
-import dev.aurelium.auraskills.api.source.CustomSource;
-import dev.aurelium.auraskills.api.source.SkillSource;
-import dev.aurelium.auraskills.api.source.SourceManager;
-import dev.aurelium.auraskills.api.source.XpSource;
+import dev.aurelium.auraskills.api.source.*;
 import dev.aurelium.auraskills.common.AuraSkillsPlugin;
 import dev.aurelium.auraskills.common.message.MessageKey;
+import dev.aurelium.auraskills.common.source.income.IncomeLoader;
 import dev.aurelium.auraskills.common.util.text.TextUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
 
 import java.util.List;
 import java.util.Locale;
@@ -16,9 +15,11 @@ import java.util.Locale;
 public class ApiSourceManager implements SourceManager {
 
     private final AuraSkillsPlugin plugin;
+    private final IncomeLoader incomeLoader;
 
     public ApiSourceManager(AuraSkillsPlugin plugin) {
         this.plugin = plugin;
+        this.incomeLoader = new IncomeLoader(plugin);
     }
 
     @Override
@@ -51,5 +52,10 @@ public class ApiSourceManager implements SourceManager {
             unitName = TextUtil.replace(unitName, "{" + keyStr + "}", message);
         }
         return unitName;
+    }
+
+    @Override
+    public SourceIncome loadSourceIncome(ConfigurationNode source) {
+        return incomeLoader.loadSourceIncome(source);
     }
 }

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/ConfigProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/ConfigProvider.java
@@ -27,4 +27,6 @@ public interface ConfigProvider {
 
     int getStartLevel();
 
+    boolean jobSelectionEnabled();
+
 }

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
@@ -37,6 +37,14 @@ public enum Option {
     BOSS_BAR_FORMAT("boss_bar.format", OptionType.LIST),
     BOSS_BAR_XP_FORMAT("boss_bar.xp_format", OptionType.STRING),
     BOSS_BAR_PERCENT_FORMAT("boss_bar.percent_format", OptionType.STRING),
+    BOSS_BAR_MONEY_FORMAT("boss_bar.money_format", OptionType.STRING),
+    // Jobs options
+    JOBS_ENABLED("jobs.enabled", OptionType.BOOLEAN),
+    JOBS_INCOME_USE_XP("jobs.income.use_xp", OptionType.BOOLEAN),
+    JOBS_INCOME_USE_EXPRESSION("jobs.income.use_expression", OptionType.BOOLEAN),
+    JOBS_INCOME_DEFAULT_INCOME_PER_XP("jobs.income.default.income_per_xp", OptionType.DOUBLE),
+    JOBS_INCOME_DEFAULT_EXPRESSION("jobs.income.default.expression", OptionType.STRING),
+    JOBS_INCOME_USE_FINAL_XP("jobs.income.use_final_xp", OptionType.BOOLEAN),
     ENABLE_ROMAN_NUMERALS("enable_roman_numerals", OptionType.BOOLEAN),
     // Damage hologram options
     DAMAGE_HOLOGRAMS_ENABLED("damage_holograms.enabled", OptionType.BOOLEAN),

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
@@ -40,6 +40,8 @@ public enum Option {
     BOSS_BAR_MONEY_FORMAT("boss_bar.money_format", OptionType.STRING),
     // Jobs options
     JOBS_ENABLED("jobs.enabled", OptionType.BOOLEAN),
+    JOBS_SELECTION_REQUIRE_SELECTION("jobs.selection.require_selection", OptionType.BOOLEAN),
+    JOBS_SELECTION_DEFAULT_JOB_LIMIT("jobs.selection.default_job_limit", OptionType.INT),
     JOBS_INCOME_USE_XP("jobs.income.use_xp", OptionType.BOOLEAN),
     JOBS_INCOME_USE_EXPRESSION("jobs.income.use_expression", OptionType.BOOLEAN),
     JOBS_INCOME_DEFAULT_INCOME_PER_XP("jobs.income.default.income_per_xp", OptionType.DOUBLE),

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
@@ -42,6 +42,7 @@ public enum Option {
     JOBS_ENABLED("jobs.enabled", OptionType.BOOLEAN),
     JOBS_SELECTION_REQUIRE_SELECTION("jobs.selection.require_selection", OptionType.BOOLEAN),
     JOBS_SELECTION_DEFAULT_JOB_LIMIT("jobs.selection.default_job_limit", OptionType.INT),
+    JOBS_SELECTION_DISABLE_UNSELECTED_XP("jobs.selection.disable_unselected_xp", OptionType.BOOLEAN),
     JOBS_INCOME_USE_XP("jobs.income.use_xp", OptionType.BOOLEAN),
     JOBS_INCOME_USE_EXPRESSION("jobs.income.use_expression", OptionType.BOOLEAN),
     JOBS_INCOME_DEFAULT_INCOME_PER_XP("jobs.income.default.income_per_xp", OptionType.DOUBLE),

--- a/common/src/main/java/dev/aurelium/auraskills/common/level/LevelManager.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/level/LevelManager.java
@@ -73,6 +73,10 @@ public abstract class LevelManager {
         if (source == null) {
             return 0.0;
         }
+        // Selection is required and job is not selected
+        if (plugin.config().jobSelectionEnabled() && !user.getJobs().contains(skill)) {
+            return 0.0;
+        }
 
         double income = source.getIncome().getIncomeEarned(user.toApi(), source.getValues(), skill, amount);
 

--- a/common/src/main/java/dev/aurelium/auraskills/common/level/LevelManager.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/level/LevelManager.java
@@ -5,6 +5,7 @@ import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.api.source.XpSource;
 import dev.aurelium.auraskills.common.AuraSkillsPlugin;
 import dev.aurelium.auraskills.common.config.Option;
+import dev.aurelium.auraskills.common.hooks.EconomyHook;
 import dev.aurelium.auraskills.common.reward.SkillReward;
 import dev.aurelium.auraskills.common.scheduler.Tick;
 import dev.aurelium.auraskills.common.user.User;
@@ -56,14 +57,30 @@ public abstract class LevelManager {
         var res = plugin.getEventHandler().callXpGainEvent(user, skill, source, amountToAdd);
         if (res.first()) return;
 
-        addXpRaw(user, skill, res.second());
+        addXpRaw(user, skill, res.second(), source);
     }
 
-    protected void addXpRaw(User user, Skill skill, double amount) {
+    protected void addXpRaw(User user, Skill skill, double amount, @Nullable XpSource xpSource) {
+        double income = addJobsIncome(user, skill, amount, xpSource);
+
         user.addSkillXp(skill, amount);
         checkLevelUp(user, skill);
         // Send action bar and boss bar
-        sendXpUi(user, skill, amount);
+        sendXpUi(user, skill, amount, income);
+    }
+
+    private double addJobsIncome(User user, Skill skill, double amount, @Nullable XpSource source) {
+        if (source == null) {
+            return 0.0;
+        }
+
+        double income = source.getIncome().getIncomeEarned(user.toApi(), source.getValues(), skill, amount);
+
+        if (income > 0 && plugin.getHookManager().isRegistered(EconomyHook.class)) {
+            EconomyHook economy = plugin.getHookManager().getHook(EconomyHook.class);
+            economy.deposit(user, income);
+        }
+        return income;
     }
 
     public void setXp(User user, Skill skill, double amount) {
@@ -75,18 +92,18 @@ public abstract class LevelManager {
         // Sends action bar message
         double xpAmount = amount - originalAmount;
 
-        sendXpUi(user, skill, xpAmount);
+        sendXpUi(user, skill, xpAmount, 0.0);
     }
 
-    private void sendXpUi(User user, Skill skill, double xpGained) {
+    private void sendXpUi(User user, Skill skill, double xpGained, double income) {
         double currentXp = user.getSkillXp(skill);
         int level = user.getSkillLevel(skill);
         double levelXp = xpRequirements.getXpRequired(skill, level + 1);
         boolean maxed = xpRequirements.getListSize(skill) <= user.getSkillLevel(skill) - 1 || level >= skill.getMaxLevel();
 
-        plugin.getUiProvider().getActionBarManager().sendXpActionBar(user, skill, currentXp, levelXp, xpGained, level, maxed);
+        plugin.getUiProvider().getActionBarManager().sendXpActionBar(user, skill, currentXp, levelXp, xpGained, level, maxed, income);
         if (plugin.configBoolean(Option.BOSS_BAR_ENABLED)) {
-            plugin.getUiProvider().sendXpBossBar(user, skill, currentXp, levelXp, xpGained, level, maxed);
+            plugin.getUiProvider().sendXpBossBar(user, skill, currentXp, levelXp, xpGained, level, maxed, income);
         }
     }
 

--- a/common/src/main/java/dev/aurelium/auraskills/common/message/type/ActionBarMessage.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/message/type/ActionBarMessage.java
@@ -11,7 +11,9 @@ public enum ActionBarMessage implements MessageKey {
     MAXED,
     ABILITY,
     BOSS_BAR_XP,
-    BOSS_BAR_MAXED;
+    BOSS_BAR_MAXED,
+    BOSS_BAR_INCOME,
+    BOSS_BAR_INCOME_MAXED;
 
     @Override
     public String getPath() {

--- a/common/src/main/java/dev/aurelium/auraskills/common/source/Source.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/source/Source.java
@@ -6,6 +6,7 @@ import dev.aurelium.auraskills.api.source.SourceValues;
 import dev.aurelium.auraskills.api.source.XpSource;
 import dev.aurelium.auraskills.common.AuraSkillsPlugin;
 import dev.aurelium.auraskills.common.message.MessageKey;
+import dev.aurelium.auraskills.api.source.SourceIncome;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
@@ -66,6 +67,15 @@ public class Source implements XpSource {
     @Override
     public double getXp() {
         return values.getXp();
+    }
+
+    public SourceIncome getIncome() {
+        return values.getIncome();
+    }
+
+    @Override
+    public SourceValues getValues() {
+        return values;
     }
 
     @Override

--- a/common/src/main/java/dev/aurelium/auraskills/common/source/income/ExpressionIncome.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/source/income/ExpressionIncome.java
@@ -1,0 +1,40 @@
+package dev.aurelium.auraskills.common.source.income;
+
+import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.data.EvaluationValue;
+import com.ezylang.evalex.parser.ParseException;
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.api.source.SourceIncome;
+import dev.aurelium.auraskills.api.source.SourceValues;
+import dev.aurelium.auraskills.api.user.SkillsUser;
+import dev.aurelium.auraskills.common.AuraSkillsPlugin;
+
+public class ExpressionIncome implements SourceIncome {
+
+    private final AuraSkillsPlugin plugin;
+    private final Expression expression;
+
+    public ExpressionIncome(AuraSkillsPlugin plugin, Expression expression) {
+        this.plugin = plugin;
+        this.expression = expression;
+    }
+
+    @Override
+    public double getIncomeEarned(SkillsUser user, SourceValues sourceValues, Skill skill, double finalXp) {
+        // Set expression variables
+        expression.with("xp", finalXp)
+                .with("base_xp", sourceValues.getXp())
+                .with("level", user.getSkillLevel(skill))
+                .with("power", user.getPowerLevel())
+                .with("skill_average", user.getSkillAverage());
+        try {
+            EvaluationValue value = expression.evaluate();
+            return value.getNumberValue().doubleValue();
+        } catch (EvaluationException | ParseException e) {
+            plugin.logger().warn("Error evaluating ExpressionIncome for source with id " + sourceValues.getId() + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/common/src/main/java/dev/aurelium/auraskills/common/source/income/FixedIncome.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/source/income/FixedIncome.java
@@ -1,0 +1,20 @@
+package dev.aurelium.auraskills.common.source.income;
+
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.api.source.SourceIncome;
+import dev.aurelium.auraskills.api.source.SourceValues;
+import dev.aurelium.auraskills.api.user.SkillsUser;
+
+public class FixedIncome implements SourceIncome {
+
+    private final double income;
+
+    public FixedIncome(double income) {
+        this.income = income;
+    }
+
+    @Override
+    public double getIncomeEarned(SkillsUser user, SourceValues sourceValues, Skill skill, double finalXp) {
+        return income;
+    }
+}

--- a/common/src/main/java/dev/aurelium/auraskills/common/source/income/IncomeLoader.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/source/income/IncomeLoader.java
@@ -1,0 +1,45 @@
+package dev.aurelium.auraskills.common.source.income;
+
+import com.ezylang.evalex.Expression;
+import dev.aurelium.auraskills.api.source.SourceIncome;
+import dev.aurelium.auraskills.common.AuraSkillsPlugin;
+import dev.aurelium.auraskills.common.config.Option;
+import org.spongepowered.configurate.ConfigurationNode;
+
+public class IncomeLoader {
+
+    private final AuraSkillsPlugin plugin;
+
+    public IncomeLoader(AuraSkillsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public SourceIncome loadSourceIncome(ConfigurationNode source) {
+        // Check income explicitly defined in the sources file
+        if (!source.node("income_per_xp").virtual()) {
+            double incomePerXp = source.node("income_per_xp").getDouble();
+            return new XpIncome(plugin, incomePerXp);
+        } else if (!source.node("income").virtual()) {
+            double income = source.node("income").getDouble();
+            return new FixedIncome(income);
+        } else if (!source.node("income_expression").virtual()) {
+            String incomeExpression = source.node("income_expression").getString();
+            Expression expression = new Expression(incomeExpression);
+            return new ExpressionIncome(plugin, expression);
+        }
+        // Use the config.yml default income
+        return getConfigDefaultIncome();
+    }
+
+    private SourceIncome getConfigDefaultIncome() {
+        if (plugin.configBoolean(Option.JOBS_INCOME_USE_EXPRESSION)) {
+            String expString = plugin.configString(Option.JOBS_INCOME_DEFAULT_EXPRESSION);
+            Expression expression = new Expression(expString);
+            return new ExpressionIncome(plugin, expression);
+        } else {
+            double incomePerXp = plugin.configDouble(Option.JOBS_INCOME_DEFAULT_INCOME_PER_XP);
+            return new XpIncome(plugin, incomePerXp);
+        }
+    }
+
+}

--- a/common/src/main/java/dev/aurelium/auraskills/common/source/income/XpIncome.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/source/income/XpIncome.java
@@ -1,0 +1,28 @@
+package dev.aurelium.auraskills.common.source.income;
+
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.api.source.SourceIncome;
+import dev.aurelium.auraskills.api.source.SourceValues;
+import dev.aurelium.auraskills.api.user.SkillsUser;
+import dev.aurelium.auraskills.common.AuraSkillsPlugin;
+import dev.aurelium.auraskills.common.config.Option;
+
+public class XpIncome implements SourceIncome {
+
+    private final AuraSkillsPlugin plugin;
+    private final double incomePerXp;
+
+    public XpIncome(AuraSkillsPlugin plugin, double incomePerXp) {
+        this.plugin = plugin;
+        this.incomePerXp = incomePerXp;
+    }
+
+    @Override
+    public double getIncomeEarned(SkillsUser user, SourceValues sourceValues, Skill skill, double finalXp) {
+        if (plugin.configBoolean(Option.JOBS_INCOME_USE_FINAL_XP)) {
+            return incomePerXp * finalXp;
+        } else {
+            return incomePerXp * sourceValues.getXp();
+        }
+    }
+}

--- a/common/src/main/java/dev/aurelium/auraskills/common/storage/file/FileStorageProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/storage/file/FileStorageProvider.java
@@ -345,7 +345,9 @@ public class FileStorageProvider extends StorageProvider {
         }
 
         // Save jobs
-        if (!user.getJobs().isEmpty()) {
+        if (user.getJobs().isEmpty()) {
+            root.removeChild("jobs");
+        } else {
             List<String> jobNames = new ArrayList<>();
             for (Skill skill : user.getJobs()) {
                 jobNames.add(skill.getId().toString());

--- a/common/src/main/java/dev/aurelium/auraskills/common/storage/file/FileStorageProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/storage/file/FileStorageProvider.java
@@ -85,6 +85,9 @@ public class FileStorageProvider extends StorageProvider {
         // Load action bar settings
         loadActionBar(root.node("action_bar"), user);
 
+        // Load jobs
+        loadJobs(root.node("jobs"), user);
+
         return user;
     }
 
@@ -183,6 +186,21 @@ public class FileStorageProvider extends StorageProvider {
             String typeName = type.toString().toLowerCase(Locale.ROOT);
             if (!node.node(typeName).virtual()) {
                 user.setActionBarSetting(type, node.node(typeName).getBoolean());
+            }
+        }
+    }
+
+    private void loadJobs(ConfigurationNode node, User user) {
+        user.clearAllJobs();
+
+        for (ConfigurationNode jobNode : node.childrenList()) {
+            String skillName = jobNode.getString();
+            if (skillName == null) continue;
+
+            Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromString(skillName));
+
+            if (skill != null) {
+                user.addJob(skill);
             }
         }
     }
@@ -324,6 +342,15 @@ public class FileStorageProvider extends StorageProvider {
             if (type != ActionBarType.IDLE) continue; // Only save idle action bar for now
             boolean value = user.isActionBarEnabled(type);
             actionBarNode.node(type.toString().toLowerCase(Locale.ROOT)).set(value);
+        }
+
+        // Save jobs
+        if (!user.getJobs().isEmpty()) {
+            List<String> jobNames = new ArrayList<>();
+            for (Skill skill : user.getJobs()) {
+                jobNames.add(skill.getId().toString());
+            }
+            root.node("jobs").set(jobNames);
         }
 
         saveYamlFile(root, user.getUuid());

--- a/common/src/main/java/dev/aurelium/auraskills/common/storage/sql/SqlStorageProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/storage/sql/SqlStorageProvider.java
@@ -225,6 +225,8 @@ public class SqlStorageProvider extends StorageProvider {
 
                     String[] splitValue = value.split(",");
                     for (String skillName : splitValue) {
+                        if (skillName.isEmpty()) continue;
+
                         NamespacedId id = NamespacedId.fromString(skillName);
                         Skill skill = plugin.getSkillRegistry().getOrNull(id);
                         if (skill == null) continue;
@@ -556,6 +558,8 @@ public class SqlStorageProvider extends StorageProvider {
     }
 
     private void saveJobs(Connection connection, int userId, Set<Skill> jobs) throws SQLException {
+        if (jobs.isEmpty()) return;
+
         String query = "INSERT INTO " + tablePrefix + "key_values (user_id, data_id, category_id, key_name, value) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE value=?";
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setInt(1, userId);

--- a/common/src/main/java/dev/aurelium/auraskills/common/ui/ActionBarManager.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/ui/ActionBarManager.java
@@ -7,6 +7,7 @@ import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.hooks.PlaceholderHook;
 import dev.aurelium.auraskills.common.message.type.ActionBarMessage;
 import dev.aurelium.auraskills.common.scheduler.TaskRunnable;
+import dev.aurelium.auraskills.common.ui.UiProvider.FormatType;
 import dev.aurelium.auraskills.common.user.User;
 import dev.aurelium.auraskills.common.util.text.TextUtil;
 import org.jetbrains.annotations.NotNull;
@@ -97,7 +98,7 @@ public abstract class ActionBarManager {
         plugin.getScheduler().timerSync(task, 0, plugin.configInt(Option.ACTION_BAR_UPDATE_PERIOD) * 50L, TimeUnit.MILLISECONDS);
     }
 
-    public void sendXpActionBar(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed) {
+    public void sendXpActionBar(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed, double income) {
         ActionBarType sendType = maxed ? ActionBarType.MAXED : ActionBarType.XP;
         // Return if the type is disabled in config
         if (!plugin.configBoolean(sendType.getOption()) || !plugin.configBoolean(Option.ACTION_BAR_ENABLED)) {
@@ -140,7 +141,7 @@ public abstract class ActionBarManager {
                         return;
                     }
 
-                    String message = getXpActionBarMessage(user, skill, currentXp, levelXp, xpGained, level, maxed);
+                    String message = getXpActionBarMessage(user, skill, currentXp, levelXp, xpGained, level, maxed, income);
                     uiProvider.sendActionBar(user, message);
                 }
             }, 0, plugin.configInt(Option.ACTION_BAR_UPDATE_PERIOD) * 50L, TimeUnit.MILLISECONDS);
@@ -203,7 +204,7 @@ public abstract class ActionBarManager {
         setPaused(user, 15 * 50, TimeUnit.MILLISECONDS);
     }
 
-    private String getXpActionBarMessage(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed) {
+    private String getXpActionBarMessage(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed, double income) {
         ActionBarMessage messageKey = maxed ? ActionBarMessage.MAXED : ActionBarMessage.XP;
         Locale locale = user.getLocale();
 
@@ -214,11 +215,12 @@ public abstract class ActionBarManager {
                 "{max_hp}", getMaxHp(user),
                 "{xp_gained}", xpGained > 0 ? "+" + NumberUtil.format1(xpGained) : NumberUtil.format1(xpGained),
                 "{skill}", skill.getDisplayName(locale),
-                "{current_xp}", NumberUtil.format1(currentXp),
+                "{current_xp}", plugin.getUiProvider().getFormat(FormatType.XP).format(currentXp),
                 "{level_xp}", NumberUtil.format1(levelXp),
                 "{skill_level}", String.valueOf(level),
                 "{mana}", getMana(user),
-                "{max_mana}", getMaxMana(user));
+                "{max_mana}", getMaxMana(user),
+                "{income}", plugin.getUiProvider().getFormat(FormatType.MONEY).format(income));
         // Replace PlaceholderAPI placeholders
         message = replacePlaceholderApi(user, message);
 

--- a/common/src/main/java/dev/aurelium/auraskills/common/ui/UiProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/ui/UiProvider.java
@@ -3,14 +3,27 @@ package dev.aurelium.auraskills.common.ui;
 import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.common.user.User;
 
+import java.text.NumberFormat;
+
 public interface UiProvider {
 
     ActionBarManager getActionBarManager();
 
+    // Allows ActionBarManager to access boss bar format options
+    NumberFormat getFormat(FormatType type);
+
     void sendActionBar(User user, String message);
 
-    void sendXpBossBar(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed);
+    void sendXpBossBar(User user, Skill skill, double currentXp, double levelXp, double xpGained, int level, boolean maxed, double income);
 
     void sendTitle(User user, String title, String subtitle, int fadeIn, int stay, int fadeOut);
+
+    enum FormatType {
+
+        XP,
+        PERCENT,
+        MONEY
+
+    }
 
 }

--- a/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
@@ -422,6 +422,7 @@ public abstract class User {
     public void addJob(Skill skill) {
         if (jobs.size() < getJobLimit()) {
             jobs.add(skill);
+            blank = false;
         }
     }
 
@@ -511,6 +512,9 @@ public abstract class User {
             if (statLevel > 0.0) {
                 return false;
             }
+        }
+        if (!jobs.isEmpty()) {
+            return false;
         }
         return statModifiers.isEmpty();
     }

--- a/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
@@ -15,6 +15,7 @@ import dev.aurelium.auraskills.api.util.AuraSkillsModifier;
 import dev.aurelium.auraskills.common.AuraSkillsPlugin;
 import dev.aurelium.auraskills.common.ability.AbilityData;
 import dev.aurelium.auraskills.common.api.implementation.ApiSkillsUser;
+import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.mana.ManaAbilityData;
 import dev.aurelium.auraskills.api.skill.Multiplier;
 import dev.aurelium.auraskills.common.ui.ActionBarType;
@@ -417,7 +418,9 @@ public abstract class User {
     }
 
     public void addJob(Skill skill) {
-        jobs.add(skill);
+        if (jobs.size() < getJobLimit()) {
+            jobs.add(skill);
+        }
     }
 
     public void removeJob(Skill skill) {
@@ -426,6 +429,10 @@ public abstract class User {
 
     public void clearAllJobs() {
         jobs.clear();
+    }
+
+    public int getJobLimit() {
+        return plugin.configInt(Option.JOBS_SELECTION_DEFAULT_JOB_LIMIT);
     }
 
     public boolean isSaving() {

--- a/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
@@ -97,6 +97,8 @@ public abstract class User {
 
     public abstract void setCommandLocale(Locale locale);
 
+    public abstract int getPermissionJobLimit();
+
     public int getSkillLevel(Skill skill) {
         return skillLevels.getOrDefault(skill, plugin.config().getStartLevel());
     }
@@ -432,6 +434,10 @@ public abstract class User {
     }
 
     public int getJobLimit() {
+        int permLimit = getPermissionJobLimit();
+        if (permLimit > 0) {
+            return permLimit;
+        }
         return plugin.configInt(Option.JOBS_SELECTION_DEFAULT_JOB_LIMIT);
     }
 

--- a/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
@@ -48,6 +48,7 @@ public abstract class User {
     private final Map<String, Object> metadata;
     private List<KeyIntPair> unclaimedItems;
     private final Map<ActionBarType, Boolean> actionBarSettings;
+    private final Set<Skill> jobs;
 
     private boolean saving;
     private boolean shouldSave;
@@ -73,6 +74,7 @@ public abstract class User {
         this.shouldSave = true;
         this.mana = Traits.MAX_MANA.isEnabled() ? Traits.MAX_MANA.optionDouble("base") : 0.0;
         this.multipliers = new HashMap<>();
+        this.jobs = new HashSet<>();
     }
 
     public AuraSkillsPlugin getPlugin() {
@@ -408,6 +410,22 @@ public abstract class User {
 
     public void setUnclaimedItems(@NotNull List<KeyIntPair> unclaimedItems) {
         this.unclaimedItems = unclaimedItems;
+    }
+
+    public Set<Skill> getJobs() {
+        return Collections.unmodifiableSet(jobs);
+    }
+
+    public void addJob(Skill skill) {
+        jobs.add(skill);
+    }
+
+    public void removeJob(Skill skill) {
+        jobs.remove(skill);
+    }
+
+    public void clearAllJobs() {
+        jobs.clear();
     }
 
     public boolean isSaving() {

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -85,7 +85,17 @@ boss_bar:
     - 'HEALING WHITE PROGRESS'
     - 'FORGING YELLOW PROGRESS'
   xp_format: '#.#'
-  percent_format: "#.##"
+  percent_format: '#.##'
+  money_format: '0.00'
+jobs:
+  enabled: true
+  income:
+    use_xp: true
+    use_expression: false
+    default:
+      income_per_xp: 0.1
+      expression: 0.1*xp
+    use_final_xp: true
 enable_roman_numerals: false
 damage_holograms:
   enabled: true

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -88,7 +88,7 @@ boss_bar:
   percent_format: '#.##'
   money_format: '0.00'
 jobs:
-  enabled: true
+  enabled: false
   selection:
     require_selection: true
     default_job_limit: 2

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -92,6 +92,7 @@ jobs:
   selection:
     require_selection: true
     default_job_limit: 2
+    disable_unselected_xp: false
   income:
     use_xp: true
     use_expression: false

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -89,6 +89,9 @@ boss_bar:
   money_format: '0.00'
 jobs:
   enabled: true
+  selection:
+    require_selection: true
+    default_job_limit: 2
   income:
     use_xp: true
     use_expression: false

--- a/common/src/main/resources/messages/global.yml
+++ b/common/src/main/resources/messages/global.yml
@@ -17,6 +17,8 @@ action_bar:
   ability: "{message}"
   boss_bar_xp: "<gold>{xp_gained} {skill} {{units.xp}} <gray>({percent}%)"
   boss_bar_maxed: "<gold>{xp_gained} {skill} {{units.xp}} <gray>({{ui.maxed}})"
+  boss_bar_income: "<gold>{xp_gained} {skill} {{units.xp}} <gray>({percent}%) <green>(+${income})"
+  boss_bar_income_maxed: "<gold>{xp_gained} {skill} {{units.xp}} <gray>({{ui.maxed}}) <green>(+${income})"
 acf:
   core:
     info_message: "{message}"
@@ -113,4 +115,4 @@ stats:
   speed:
     color: "<white>"
     symbol: "➤"
-file_version: 1
+file_version: 2

--- a/common/src/main/resources/messages/messages_en.yml
+++ b/common/src/main/resources/messages/messages_en.yml
@@ -591,7 +591,7 @@ menus:
     job_select: Left click to select {skill} as your job
     job_active: You are actively working this job
     job_quit: Right click to quit this job
-    job_limit: You have reached your limit on jobs. Quit another job to be able to select this one.
+    job_limit: You have reached your limit on jobs. Quit an active job first to select this one.
   stats:
     stats_title: Your Stats
     skills: "Skills"

--- a/common/src/main/resources/messages/messages_en.yml
+++ b/common/src/main/resources/messages/messages_en.yml
@@ -568,6 +568,7 @@ menus:
     stats: "Stats"
     stats_desc: "Earn stat buffs by leveling up skills"
     stats_click: "Click to learn more or view your stats"
+    active_job: Active Job
   level_progression:
     level_progression_title: "{skill} Levels - Page {page}"
     your_ranking: "Your Skill Ranking"
@@ -585,6 +586,12 @@ menus:
     abilities_desc: "<2>Abilities</2> <1>are passive perks you unlock and upgrade as you level up skills.</1>"
     mana_abilities_desc: "<3>Mana Abilities</3> <1>are a special type of ability that requires activation and consumes mana.</1>"
     abilities_click: "Click to view {skill} abilities"
+    job: Job
+    job_desc: Selecting {skill} as your job allows you to earn money while gaining XP.
+    job_select: Left click to select {skill} as your job
+    job_active: You are actively working this job
+    job_quit: Right click to quit this job
+    job_limit: You have reached your limit on jobs. Quit another job to be able to select this one.
   stats:
     stats_title: Your Stats
     skills: "Skills"
@@ -849,4 +856,4 @@ units:
   mana: Mana
   hp: HP
   xp: XP
-file_version: 33
+file_version: 34


### PR DESCRIPTION
Jobs is an optional feature that allows players to select skills as jobs to earn money while gaining XP.

Features:

- To use jobs, the jobs.enabled option must be set to true in config.yml
- Income for all XP sources is configured under jobs.income
  - If use_xp is true, sources will give a multiple of the XP gained based on default.income_per_xp
  - If use_expression is true, sources will give XP based on the result of default.expression
    - The available variables include xp, base_xp (value without multipliers), level (skill level), power, and skill_average
  - If use_final_xp is set to false, the calculation for income_per_xp will exclude all XP multipliers
- Job selection is configured under jobs.selection
  - Players select a skill as a job using a new item in the level progression menu of a skill (gold_ingot by default)
  - If require_selection is set to false, players will gain income for all skills and selection will be hidden
  - The default_job_limit is the maximum number of skills that can be selected as jobs at the same time
  - The limit can be changed per-player using the auraskills.jobs.limit.[number] permission node (ex: auraskills.jobs.limit.4)
  - The disable_unselected_xp option will block gaining XP in all skills that are not active jobs if set to true
- Income can also be configured per-source inside the sources files
  - Keys can be added to both the default section or an individual source
  - The following keys can be added to a source:
    - income_per_xp - The income to give per XP gained, works the same as the value in config.yml
    - income - A fixed decimal value for the money to give
    - income_expression - An expression to calculate the income, works the same as the expression in config.yml
- Menu files will automatically update to add the new items and components to show job selection
  - However, you must manually add a new line `- component: skill_job_active` to the lore of the skill template in menus/skills.yml under `- component: max_level`
  - Everything will still work if this line isn't manually added, players just won't see the "Active Job" displayed in the skills menu