### PR TITLE
Fix double reloading on addStatModifier

### DIFF
--- a/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
@@ -265,7 +265,10 @@ public abstract class User {
             if (oldModifier.type() == modifier.type() && oldModifier.value() == modifier.value()) {
                 return;
             }
-            removeModifier(modifier.name(), reload, map, levels);
+            // Do not reload on remove since that would reset health and other stuff (mainly for 3rd party plugins)
+            // Reload will happen at the end of this method if it was true either way.
+            // So here we are just preventing double stat reload.
+            removeModifier(modifier.name(), false, map, levels);
         }
         map.put(modifier.name(), modifier);
         if (levels != null) {


### PR DESCRIPTION
- checked with armor/item modifiers, it doesn't seem to break any internal behavior
- fixes compatibility with 3rd party plugins that are adding stat modifiers over and over again with the same key (almost all of them doing this)
- also tested with latest MythicMobs dev build and with latest MythicLib and MMOItems dev build.