### PR TITLE
Add boss bar animation when it appears 

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
@@ -209,7 +209,7 @@ public class BossBarManager implements Listener {
 
         plugin.getAudiences().player(player).showBossBar(bossBar);
 
-        // Boss bar progress is updated later, so the player sees the animation going from old progress to new
+        // Boss bar progress is updated later, so the player sees the animation going from previous progress to new
         plugin.getScheduler().scheduleSync(() -> bossBar.progress(progress), 2 * 50, TimeUnit.MILLISECONDS);
     }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
@@ -188,17 +188,14 @@ public class BossBarManager implements Listener {
 
         Component name = tf.toComponent(text);
 
-        if (!ANIMATE_PROGRESS) {
-            progressOld = progressNew;
-        }
-
         BossBar bossBar = BossBar.bossBar(name, progressOld, color, overlay);
-
-        plugin.getAudiences().player(player).showBossBar(bossBar);
-        if (ANIMATE_PROGRESS) {
-            // Boss bar progress is updated later, so the player sees the animation going from progressOld to progressNew
+        if (!ANIMATE_PROGRESS) {  // If the config option is disabled, immediately show new progress
+            bossBar.progress(progressNew);
+        } else {  // Update the progress later to display its animation from progressOld to progressNew
             plugin.getScheduler().scheduleSync(() -> bossBar.progress(progressNew), 2 * 50, TimeUnit.MILLISECONDS);
         }
+        plugin.getAudiences().player(player).showBossBar(bossBar);
+
         // Add to maps
         if (mode.equals("single")) {
             singleBossBars.put(player.getUniqueId(), bossBar);
@@ -212,18 +209,15 @@ public class BossBarManager implements Listener {
         final boolean ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
         Component name = tf.toComponent(text);
 
-        if (!ANIMATE_PROGRESS) {
+        if (!ANIMATE_PROGRESS) {  // Update boss bar progress immediately
             bossBar.progress(progress);
+        } else {  // Update progress later, so the player sees the animation from previous progress (from reused boss bar) to new
+            plugin.getScheduler().scheduleSync(() -> bossBar.progress(progress), 2 * 50, TimeUnit.MILLISECONDS);
         }
         bossBar.name(name); // Update the boss bar to the new text value
         bossBar.color(getColor(skill));
 
         plugin.getAudiences().player(player).showBossBar(bossBar);
-
-        if (ANIMATE_PROGRESS) {
-            // Boss bar progress is updated later, so the player sees the animation going from previous progress to new
-            plugin.getScheduler().scheduleSync(() -> bossBar.progress(progress), 2 * 50, TimeUnit.MILLISECONDS);
-        }
     }
 
     private String getBossBarText(Player player, Skill skill, double currentXp, long levelXp, double xpGained, int level, boolean maxed, double income, Locale locale) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
@@ -46,6 +46,7 @@ public class BossBarManager implements Listener {
     private NumberFormat moneyFormat;
     private final AuraSkills plugin;
     private final TextFormatter tf = new TextFormatter();
+    private final boolean ANIMATE_PROGRESS;
 
     public BossBarManager(AuraSkills plugin) {
         this.bossBars = new HashMap<>();
@@ -56,6 +57,7 @@ public class BossBarManager implements Listener {
         this.checkCurrentActions = new HashMap<>();
         this.singleCheckCurrentActions = new HashMap<>();
         loadNumberFormats();
+        this.ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
     }
 
     public NumberFormat getXpFormat() {
@@ -182,7 +184,6 @@ public class BossBarManager implements Listener {
     }
 
     private BossBar handleNewBossBar(Player player, Skill skill, float progressOld, float progressNew, String text) {
-        final boolean ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
         BossBar.Color color = getColor(skill);
         BossBar.Overlay overlay = getOverlay(skill);
 
@@ -206,7 +207,6 @@ public class BossBarManager implements Listener {
     }
 
     private void handleExistingBossBar(BossBar bossBar, Player player, Skill skill, float progress, String text) {
-        final boolean ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
         Component name = tf.toComponent(text);
 
         if (!ANIMATE_PROGRESS) {  // Update boss bar progress immediately

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
@@ -157,13 +157,20 @@ public class BossBarManager implements Listener {
             bossBar = bossBars.get(playerId).get(skill);
         }
         String text = getBossBarText(player, skill, currentXp, (long) levelXp, xpGained, level, maxed, income, plugin.getLocale(player));
+        // Calculate xp progress
+        float progressNew = (float) (currentXp / levelXp);
+        if (progressNew > 1 || progressNew < 0) {
+            progressNew = 1.0f;
+        }
         // If player does not have a boss bar in that skill
         if (bossBar == null) {
-            bossBar = handleNewBossBar(player, skill, currentXp, levelXp, text);
+            // Calculate progress before gaining xp, for boss bar animation
+            float progressOld = (float) (Math.max(currentXp - xpGained, 0) / levelXp);
+            bossBar = handleNewBossBar(player, skill, progressOld > 1 ? 1.0f : progressOld, progressNew, text);
         }
         // Use existing one
         else {
-            handleExistingBossBar(bossBar, player, skill, currentXp, levelXp, text);
+            handleExistingBossBar(bossBar, player, skill, progressNew, text);
         }
         // Increment current action
         if (mode.equals("single")) {
@@ -174,20 +181,17 @@ public class BossBarManager implements Listener {
         scheduleHide(playerId, skill, bossBar); // Schedule tasks to hide the boss bar
     }
 
-    private BossBar handleNewBossBar(Player player, Skill skill, double currentXp, double levelXp, String text) {
+    private BossBar handleNewBossBar(Player player, Skill skill, float progressOld, float progressNew, String text) {
         BossBar.Color color = getColor(skill);
         BossBar.Overlay overlay = getOverlay(skill);
 
         Component name = tf.toComponent(text);
 
-        // Calculate xp progress
-        double progress = currentXp / levelXp;
-        if (progress > 1 || progress < 0) {
-            progress = 1.0;
-        }
-        BossBar bossBar = BossBar.bossBar(name, (float) progress, color, overlay);
+        BossBar bossBar = BossBar.bossBar(name, progressOld, color, overlay);
 
         plugin.getAudiences().player(player).showBossBar(bossBar);
+        // Boss bar progress is updated later, so the player sees the animation going from progressOld to progressNew
+        plugin.getScheduler().scheduleSync(() -> bossBar.progress(progressNew), 2 * 50, TimeUnit.MILLISECONDS);
         // Add to maps
         if (mode.equals("single")) {
             singleBossBars.put(player.getUniqueId(), bossBar);
@@ -197,19 +201,16 @@ public class BossBarManager implements Listener {
         return bossBar;
     }
 
-    private void handleExistingBossBar(BossBar bossBar, Player player, Skill skill, double currentXp, double levelXp, String text) {
+    private void handleExistingBossBar(BossBar bossBar, Player player, Skill skill, float progress, String text) {
         Component name = tf.toComponent(text);
 
         bossBar.name(name); // Update the boss bar to the new text value
-        // Calculate xp progress
-        double progress = currentXp / levelXp;
-        if (progress > 1 || progress < 0) {
-            progress = 1.0;
-        }
-        bossBar.progress((float) progress);
         bossBar.color(getColor(skill));
 
         plugin.getAudiences().player(player).showBossBar(bossBar);
+
+        // Boss bar progress is updated later, so the player sees the animation going from old progress to new
+        plugin.getScheduler().scheduleSync(() -> bossBar.progress(progress), 2 * 50, TimeUnit.MILLISECONDS);
     }
 
     private String getBossBarText(Player player, Skill skill, double currentXp, long levelXp, double xpGained, int level, boolean maxed, double income, Locale locale) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
@@ -46,7 +46,6 @@ public class BossBarManager implements Listener {
     private NumberFormat moneyFormat;
     private final AuraSkills plugin;
     private final TextFormatter tf = new TextFormatter();
-    private final boolean ANIMATE_PROGRESS;
 
     public BossBarManager(AuraSkills plugin) {
         this.bossBars = new HashMap<>();
@@ -57,7 +56,6 @@ public class BossBarManager implements Listener {
         this.checkCurrentActions = new HashMap<>();
         this.singleCheckCurrentActions = new HashMap<>();
         loadNumberFormats();
-        this.ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
     }
 
     public NumberFormat getXpFormat() {
@@ -184,6 +182,7 @@ public class BossBarManager implements Listener {
     }
 
     private BossBar handleNewBossBar(Player player, Skill skill, float progressOld, float progressNew, String text) {
+        final boolean ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
         BossBar.Color color = getColor(skill);
         BossBar.Overlay overlay = getOverlay(skill);
 
@@ -210,6 +209,7 @@ public class BossBarManager implements Listener {
     }
 
     private void handleExistingBossBar(BossBar bossBar, Player player, Skill skill, float progress, String text) {
+        final boolean ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
         Component name = tf.toComponent(text);
 
         if (!ANIMATE_PROGRESS) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/ui/BossBarManager.java
@@ -46,7 +46,7 @@ public class BossBarManager implements Listener {
     private NumberFormat moneyFormat;
     private final AuraSkills plugin;
     private final TextFormatter tf = new TextFormatter();
-    private final boolean ANIMATE_PROGRESS;
+    private boolean ANIMATE_PROGRESS;
 
     public BossBarManager(AuraSkills plugin) {
         this.bossBars = new HashMap<>();
@@ -91,6 +91,7 @@ public class BossBarManager implements Listener {
         stayTime = plugin.configInt(Option.BOSS_BAR_STAY_TIME);
         colors = new HashMap<>();
         overlays = new HashMap<>();
+        ANIMATE_PROGRESS = plugin.configBoolean(Option.BOSS_BAR_ANIMATE_PROGRESS);
         for (String entry : plugin.configStringList(Option.BOSS_BAR_FORMAT)) {
             String[] splitEntry = entry.split(" ");
             Skill skill;

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
@@ -45,6 +45,7 @@ public enum Option {
     BOSS_BAR_XP_FORMAT("boss_bar.xp_format", OptionType.STRING),
     BOSS_BAR_PERCENT_FORMAT("boss_bar.percent_format", OptionType.STRING),
     BOSS_BAR_MONEY_FORMAT("boss_bar.money_format", OptionType.STRING),
+    BOSS_BAR_ANIMATE_PROGRESS("boss_bar.animate_progress", OptionType.BOOLEAN),
     // Jobs options
     JOBS_ENABLED("jobs.enabled", OptionType.BOOLEAN),
     JOBS_SELECTION_REQUIRE_SELECTION("jobs.selection.require_selection", OptionType.BOOLEAN),

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -97,6 +97,7 @@ boss_bar:
   xp_format: '#.#'
   percent_format: '#.##'
   money_format: '0.00'
+  animate_progress: true
 jobs:
   enabled: false
   selection:


### PR DESCRIPTION
Here is a brief summary of the changes:
- Removed code duplication: calculating progress as double and casting it to float in `bossBar#progress(float)` method.
```java
double progress = currentXp / levelXp;
if (progress > 1 || progress < 0) {
    progress = 1.0;
}
```
- Changed signature of methods `handleNewBossBar` and`handleExistingBossBar` to take progress instead of currentXp and levelXp, and progress as float instead of double
- Added a comment that explains it 

![2024-07-0121-05-48-ezgif com-video-to-gif-converter (1)](https://github.com/Archy-X/AuraSkills/assets/65848142/71b49bdd-e047-4e6a-a574-ee7382900a56)



note that the first commit bf80e34 should have been amended but git complained with merge conflicts, so it looks like it got duplicated at 10c922e