### PR TITLE
Add ability to catch entities with fishing

### DIFF
--- a/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/loot/LootDropEvent.java
+++ b/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/loot/LootDropEvent.java
@@ -2,12 +2,15 @@ package dev.aurelium.auraskills.api.event.loot;
 
 import dev.aurelium.auraskills.api.user.SkillsUser;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Called when AuraSkills drops extra loot from mechanics like Fishing, Luck, and custom loot tables.
@@ -22,6 +25,7 @@ public class LootDropEvent extends Event implements Cancellable {
     private Location location;
     private final Cause cause;
     private boolean toInventory;
+    private Entity entity;
     private boolean cancelled = false;
 
     public LootDropEvent(Player player, SkillsUser user, ItemStack item, Location location, Cause cause, boolean toInventory) {
@@ -31,6 +35,26 @@ public class LootDropEvent extends Event implements Cancellable {
         this.location = location;
         this.cause = cause;
         this.toInventory = toInventory;
+    }
+
+    public LootDropEvent(Player player, SkillsUser user, Entity entity, Location location, Cause cause) {
+        this.player = player;
+        this.user = user;
+        this.location = location;
+        this.cause = cause;
+        this.toInventory = false;
+        this.entity = entity;
+        // Let's not break things and make the item not nullable still
+        this.item = new ItemStack(Material.AIR);
+    }
+
+    /**
+     * Gets the spawned entity if the loot was an entity.
+     *
+     * @return the entity
+     */
+    public @Nullable Entity getEntity() {
+        return entity;
     }
 
     /**
@@ -53,6 +77,7 @@ public class LootDropEvent extends Event implements Cancellable {
 
     /**
      * Gets the item that will be dropped by the event.
+     * If the drop is an entity, this will be AIR.
      *
      * @return the item
      */

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
@@ -4,6 +4,7 @@ import dev.aurelium.auraskills.api.event.damage.DamageEvent;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.bukkit.damage.DamageHandler;
 import dev.aurelium.auraskills.bukkit.damage.DamageResult;
+import dev.aurelium.auraskills.bukkit.hooks.mythicmobs.loot.MythicEntityLootParser;
 import dev.aurelium.auraskills.common.hooks.Hook;
 import dev.aurelium.auraskills.api.damage.DamageType;
 import io.lumine.mythic.api.adapters.AbstractEntity;
@@ -30,6 +31,10 @@ public class MythicMobsHook extends Hook implements Listener {
         super(plugin, config);
         this.plugin = plugin;
         this.damageHandler = new DamageHandler();
+
+        // Wait for loot manager to be created, but add parser before it is loaded
+        plugin.getScheduler().executeSync(() ->
+                plugin.getLootTableManager().getLootManager().registerCustomEntityParser(new MythicEntityLootParser()));
     }
 
     @EventHandler(priority = EventPriority.HIGH)

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntityLootParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntityLootParser.java
@@ -14,6 +14,6 @@ public class MythicEntityLootParser implements CustomEntityParser {
 
     @Override
     public boolean shouldUseParser(ConfigurationNode config) {
-        return config.node("entity").getString().startsWith("mythicmobs:");
+        return config.node("entity").getString("").startsWith("mythicmobs:");
     }
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntityLootParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntityLootParser.java
@@ -1,0 +1,19 @@
+package dev.aurelium.auraskills.bukkit.hooks.mythicmobs.loot;
+
+import dev.aurelium.auraskills.bukkit.loot.entity.EntityProperties;
+import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
+import dev.aurelium.auraskills.bukkit.loot.parser.CustomEntityParser;
+import org.spongepowered.configurate.ConfigurationNode;
+
+public class MythicEntityLootParser implements CustomEntityParser {
+
+    @Override
+    public EntitySupplier getEntitySupplier(ConfigurationNode config) {
+        return new MythicEntitySupplier(EntityProperties.fromConfig(config));
+    }
+
+    @Override
+    public boolean shouldUseParser(ConfigurationNode config) {
+        return config.node("entity").getString().startsWith("mythicmobs:");
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntitySupplier.java
@@ -18,7 +18,7 @@ public class MythicEntitySupplier extends EntitySupplier {
     public Entity spawnEntity(AuraSkills plugin, Location location) {
         ActiveMob activeMob;
 
-        if(getEntityProperties().level() != null) {
+        if (getEntityProperties().level() != null) {
             activeMob = MythicBukkit.inst().getMobManager().spawnMob(getEntityProperties().entityId(), location, getEntityProperties().level());
         } else {
             activeMob = MythicBukkit.inst().getMobManager().spawnMob(getEntityProperties().entityId(), location);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntitySupplier.java
@@ -1,0 +1,34 @@
+package dev.aurelium.auraskills.bukkit.hooks.mythicmobs.loot;
+
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.bukkit.loot.entity.EntityProperties;
+import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.core.mobs.ActiveMob;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+
+public class MythicEntitySupplier extends EntitySupplier {
+    public MythicEntitySupplier(EntityProperties entityProperties) {
+        super(entityProperties);
+    }
+
+    @Override
+    public Entity spawnEntity(AuraSkills plugin, Location location) {
+        ActiveMob activeMob;
+
+        if(getEntityProperties().level() != null) {
+            activeMob = MythicBukkit.inst().getMobManager().spawnMob(getEntityProperties().entityId(), location, getEntityProperties().level());
+        } else {
+            activeMob = MythicBukkit.inst().getMobManager().spawnMob(getEntityProperties().entityId(), location);
+        }
+
+        return BukkitAdapter.adapt(activeMob.getEntity());
+    }
+
+    @Override
+    public void removeEntity(Entity entity) {
+        MythicBukkit.inst().getMobManager().getActiveMob(entity.getUniqueId()).ifPresent(ActiveMob::remove);
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/loot/MythicEntitySupplier.java
@@ -10,6 +10,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
 public class MythicEntitySupplier extends EntitySupplier {
+
     public MythicEntitySupplier(EntityProperties entityProperties) {
         super(entityProperties);
     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/LootLoader.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/LootLoader.java
@@ -3,6 +3,7 @@ package dev.aurelium.auraskills.bukkit.loot;
 import dev.aurelium.auraskills.api.loot.*;
 import dev.aurelium.auraskills.api.registry.NamespacedId;
 import dev.aurelium.auraskills.bukkit.loot.parser.CommandLootParser;
+import dev.aurelium.auraskills.bukkit.loot.parser.EntityLootParser;
 import dev.aurelium.auraskills.bukkit.loot.parser.ItemLootParser;
 import dev.aurelium.auraskills.bukkit.loot.parser.LootParsingContextImpl;
 import dev.aurelium.auraskills.bukkit.util.VersionUtils;
@@ -70,6 +71,9 @@ public class LootLoader extends Parser {
                     // Command loot
                     else if (lootType.equalsIgnoreCase("command")) {
                         loot = new CommandLootParser().parse(context, lootNode);
+                    // Entity loot, mainly for fishing
+                    } else if (lootType.equalsIgnoreCase("entity")) {
+                        loot = new EntityLootParser(manager).parse(context, lootNode);
                     } else {
                         // Parse custom loot registered from API
                         LootParser customParser = manager.getCustomLootParsers().get(lootType);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/LootManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/LootManager.java
@@ -3,6 +3,7 @@ package dev.aurelium.auraskills.bukkit.loot;
 import dev.aurelium.auraskills.api.loot.LootParser;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.bukkit.loot.context.ContextProvider;
+import dev.aurelium.auraskills.bukkit.loot.parser.CustomEntityParser;
 import dev.aurelium.auraskills.bukkit.loot.parser.CustomItemParser;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,6 +17,7 @@ public class LootManager {
     private final Set<String> lootOptionKeys;
     private final Set<String> poolOptionKeys;
     private final List<CustomItemParser> customItemParsers;
+    private final List<CustomEntityParser> customEntityParsers;
     private final Map<String, LootParser> customLootParsers;
 
     public LootManager(AuraSkills plugin) {
@@ -24,6 +26,7 @@ public class LootManager {
         this.contextProviders = new HashMap<>();
         this.lootOptionKeys = new HashSet<>();
         this.poolOptionKeys = new HashSet<>();
+        this.customEntityParsers = new ArrayList<>();
         this.customItemParsers = new ArrayList<>();
         this.customLootParsers = new HashMap<>();
     }
@@ -77,8 +80,16 @@ public class LootManager {
         return customItemParsers;
     }
 
+    public List<CustomEntityParser> getCustomEntityParsers() {
+        return customEntityParsers;
+    }
+
     public void registerCustomItemParser(CustomItemParser customItemParser) {
         customItemParsers.add(customItemParser);
+    }
+
+    public void registerCustomEntityParser(CustomEntityParser customEntityParser) {
+        customEntityParsers.add(customEntityParser);
     }
 
     public Map<String, LootParser> getCustomLootParsers() {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/LootTableManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/LootTableManager.java
@@ -8,6 +8,7 @@ import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.bukkit.loot.context.MobContextProvider;
 import dev.aurelium.auraskills.bukkit.loot.context.SourceContextProvider;
+import dev.aurelium.auraskills.bukkit.loot.entity.VanillaEntityParser;
 import dev.aurelium.auraskills.bukkit.util.ItemUtils;
 import dev.aurelium.auraskills.common.api.ApiAuraSkills;
 import dev.aurelium.auraskills.common.config.ConfigurateLoader;
@@ -44,6 +45,7 @@ public class LootTableManager {
 		lootManager.registerContextProvider(new SourceContextProvider(plugin));
 		lootManager.registerContextProvider(new MobContextProvider());
 		lootManager.registerCustomItemParser(new ItemKeyParser(plugin));
+		lootManager.registerCustomEntityParser(new VanillaEntityParser());
 		lootManager.addLootOptionKeys("xp");
 		lootManager.addPoolOptionKeys("chance_per_luck", "require_open_water");
 	}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntityProperties.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntityProperties.java
@@ -1,0 +1,26 @@
+package dev.aurelium.auraskills.bukkit.loot.entity;
+
+import org.spongepowered.configurate.ConfigurationNode;
+
+public record EntityProperties(String entityId,
+                               String name,
+                               Integer level,
+                               Double health,
+                               Double damage,
+                               Float horizontalVelocity,
+                               Float verticalVelocity) {
+
+    public static EntityProperties fromConfig(ConfigurationNode config) {
+        String[] id = config.node("entity").getString().split(":");
+
+        return new EntityProperties(
+                id.length > 1 ? id[1] : id[0],
+                config.node("name").getString(),
+                config.node("level").empty() ? null :config.node("level").getInt(),
+                config.node("health").empty() ? null : config.node("health").getDouble(),
+                config.node("damage").empty() ? null :config.node("damage").getDouble(),
+                config.node("velocity", "horizontal").empty() ? null : config.node("velocity", "horizontal").getFloat(),
+                config.node("velocity", "vertical").empty() ? null : config.node("velocity", "vertical").getFloat()
+        );
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntityProperties.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntityProperties.java
@@ -11,7 +11,7 @@ public record EntityProperties(String entityId,
                                Float verticalVelocity) {
 
     public static EntityProperties fromConfig(ConfigurationNode config) {
-        String[] id = config.node("entity").getString().split(":");
+        String[] id = config.node("entity").getString("").split(":");
 
         return new EntityProperties(
                 id.length > 1 ? id[1] : id[0],

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntityProperties.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntityProperties.java
@@ -16,9 +16,9 @@ public record EntityProperties(String entityId,
         return new EntityProperties(
                 id.length > 1 ? id[1] : id[0],
                 config.node("name").getString(),
-                config.node("level").empty() ? null :config.node("level").getInt(),
+                config.node("level").empty() ? null : config.node("level").getInt(),
                 config.node("health").empty() ? null : config.node("health").getDouble(),
-                config.node("damage").empty() ? null :config.node("damage").getDouble(),
+                config.node("damage").empty() ? null : config.node("damage").getDouble(),
                 config.node("velocity", "horizontal").empty() ? null : config.node("velocity", "horizontal").getFloat(),
                 config.node("velocity", "vertical").empty() ? null : config.node("velocity", "vertical").getFloat()
         );

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntitySupplier.java
@@ -5,6 +5,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
 public abstract class EntitySupplier {
+    
     private final EntityProperties entityProperties;
 
     public EntitySupplier(EntityProperties entityProperties) {
@@ -12,6 +13,7 @@ public abstract class EntitySupplier {
     }
 
     public abstract Entity spawnEntity(AuraSkills plugin, Location location);
+
     public abstract void removeEntity(Entity entity);
 
     public EntityProperties getEntityProperties() {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/EntitySupplier.java
@@ -1,0 +1,20 @@
+package dev.aurelium.auraskills.bukkit.loot.entity;
+
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+
+public abstract class EntitySupplier {
+    private final EntityProperties entityProperties;
+
+    public EntitySupplier(EntityProperties entityProperties) {
+        this.entityProperties = entityProperties;
+    }
+
+    public abstract Entity spawnEntity(AuraSkills plugin, Location location);
+    public abstract void removeEntity(Entity entity);
+
+    public EntityProperties getEntityProperties() {
+        return entityProperties;
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntityParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntityParser.java
@@ -4,6 +4,7 @@ import dev.aurelium.auraskills.bukkit.loot.parser.CustomEntityParser;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public class VanillaEntityParser implements CustomEntityParser {
+
     @Override
     public EntitySupplier getEntitySupplier(ConfigurationNode config) {
         return new VanillaEntitySupplier(EntityProperties.fromConfig(config));
@@ -13,8 +14,10 @@ public class VanillaEntityParser implements CustomEntityParser {
     public boolean shouldUseParser(ConfigurationNode config) {
         String entity = config.node("entity").getString();
 
+        if (entity == null) return false;
+
         // If it has a colon, it's a custom entity
         // But if it starts with minecraft:, it's a vanilla entity stated explicitly
-        return !entity.contains(":") || config.node("entity").getString().startsWith("minecraft:");
+        return !entity.contains(":") || entity.startsWith("minecraft:");
     }
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntityParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntityParser.java
@@ -1,0 +1,20 @@
+package dev.aurelium.auraskills.bukkit.loot.entity;
+
+import dev.aurelium.auraskills.bukkit.loot.parser.CustomEntityParser;
+import org.spongepowered.configurate.ConfigurationNode;
+
+public class VanillaEntityParser implements CustomEntityParser {
+    @Override
+    public EntitySupplier getEntitySupplier(ConfigurationNode config) {
+        return new VanillaEntitySupplier(EntityProperties.fromConfig(config));
+    }
+
+    @Override
+    public boolean shouldUseParser(ConfigurationNode config) {
+        String entity = config.node("entity").getString();
+
+        // If it has a colon, it's a custom entity
+        // But if it starts with minecraft:, it's a vanilla entity stated explicitly
+        return !entity.contains(":") || config.node("entity").getString().startsWith("minecraft:");
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
@@ -2,7 +2,9 @@ package dev.aurelium.auraskills.bukkit.loot.entity;
 
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -16,15 +18,24 @@ public class VanillaEntitySupplier extends EntitySupplier {
 
     @Override
     public Entity spawnEntity(AuraSkills plugin, Location location) {
-        Entity entity = location.getWorld().spawnEntity(location, EntityType.valueOf(getEntityProperties().entityId().toUpperCase()));
+        World world = location.getWorld();
+        if (world == null) return null;
+
+        Entity entity = world.spawnEntity(location, EntityType.valueOf(getEntityProperties().entityId().toUpperCase()));
 
         if (entity instanceof LivingEntity livingEntity) {
             if (getEntityProperties().health() != null) {
-                livingEntity.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(getEntityProperties().health());
-                livingEntity.setHealth(getEntityProperties().health());
+                AttributeInstance attribute = livingEntity.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+                if (attribute != null) {
+                    attribute.setBaseValue(getEntityProperties().health());
+                    livingEntity.setHealth(Math.min(getEntityProperties().health(), attribute.getValue()));
+                }
             }
             if (getEntityProperties().damage() != null) {
-                livingEntity.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE).setBaseValue(getEntityProperties().damage());
+                AttributeInstance attribute = livingEntity.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
+                if (attribute != null) {
+                    attribute.setBaseValue(getEntityProperties().damage());
+                }
             }
         }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
@@ -2,14 +2,11 @@ package dev.aurelium.auraskills.bukkit.loot.entity;
 
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.metadata.MetadataValue;
-import org.bukkit.persistence.PersistentDataType;
 
 public class VanillaEntitySupplier extends EntitySupplier {
 
@@ -37,7 +34,7 @@ public class VanillaEntitySupplier extends EntitySupplier {
         }
 
         if (getEntityProperties().level() != null) {
-            entity.setMetadata("aura_skills_level", new FixedMetadataValue(plugin, getEntityProperties().level()));
+            entity.setMetadata("auraskills_level", new FixedMetadataValue(plugin, getEntityProperties().level()));
         }
 
         return entity;

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
@@ -1,0 +1,43 @@
+package dev.aurelium.auraskills.bukkit.loot.entity;
+
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+
+public class VanillaEntitySupplier extends EntitySupplier {
+
+    public VanillaEntitySupplier(EntityProperties entityProperties) {
+        super(entityProperties);
+    }
+
+    @Override
+    public Entity spawnEntity(AuraSkills plugin, Location location) {
+        Entity entity = location.getWorld().spawnEntity(location, EntityType.valueOf(getEntityProperties().entityId().toUpperCase()));
+
+        if (entity instanceof LivingEntity livingEntity) {
+            if (getEntityProperties().health() != null) {
+                livingEntity.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(getEntityProperties().health());
+                livingEntity.setHealth(getEntityProperties().health());
+            }
+            if (getEntityProperties().damage() != null) {
+                livingEntity.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE).setBaseValue(getEntityProperties().damage());
+            }
+        }
+
+        if (getEntityProperties().name() != null) {
+            entity.setCustomName(plugin.getMessageProvider().applyFormatting(getEntityProperties().name()));
+            entity.setCustomNameVisible(true);
+        }
+
+
+        return entity;
+    }
+
+    @Override
+    public void removeEntity(Entity entity) {
+        entity.remove();
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/entity/VanillaEntitySupplier.java
@@ -2,10 +2,14 @@ package dev.aurelium.auraskills.bukkit.loot.entity;
 
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.metadata.MetadataValue;
+import org.bukkit.persistence.PersistentDataType;
 
 public class VanillaEntitySupplier extends EntitySupplier {
 
@@ -32,6 +36,9 @@ public class VanillaEntitySupplier extends EntitySupplier {
             entity.setCustomNameVisible(true);
         }
 
+        if (getEntityProperties().level() != null) {
+            entity.setMetadata("aura_skills_level", new FixedMetadataValue(plugin, getEntityProperties().level()));
+        }
 
         return entity;
     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/FishingLootHandler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/FishingLootHandler.java
@@ -105,7 +105,7 @@ public class FishingLootHandler extends LootHandler implements Listener {
                 } else if (selectedLoot instanceof CommandLoot commandLoot) {
                     giveCommandLoot(player, commandLoot, source, skill);
                 } else if (selectedLoot instanceof EntityLoot entityLoot) {
-                    giveFishingEntityLoot(player, entityLoot, event, source, skill, cause, table);
+                    giveFishingEntityLoot(player, entityLoot, event, source, skill, cause);
                 }
                 break; // Stop iterating pools
             }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/FishingLootHandler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/FishingLootHandler.java
@@ -15,6 +15,7 @@ import dev.aurelium.auraskills.api.loot.LootPool;
 import dev.aurelium.auraskills.api.loot.LootTable;
 import dev.aurelium.auraskills.bukkit.loot.context.SourceContext;
 import dev.aurelium.auraskills.bukkit.loot.type.CommandLoot;
+import dev.aurelium.auraskills.bukkit.loot.type.EntityLoot;
 import dev.aurelium.auraskills.bukkit.loot.type.ItemLoot;
 import dev.aurelium.auraskills.bukkit.source.FishingLeveler;
 import dev.aurelium.auraskills.bukkit.util.VersionUtils;
@@ -103,6 +104,8 @@ public class FishingLootHandler extends LootHandler implements Listener {
                     giveFishingItemLoot(player, itemLoot, event, source, skill, cause, table);
                 } else if (selectedLoot instanceof CommandLoot commandLoot) {
                     giveCommandLoot(player, commandLoot, source, skill);
+                } else if (selectedLoot instanceof EntityLoot entityLoot) {
+                    giveFishingEntityLoot(player, entityLoot, event, source, skill, cause, table);
                 }
                 break; // Stop iterating pools
             }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/LootHandler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/LootHandler.java
@@ -137,10 +137,10 @@ public abstract class LootHandler {
         itemEntity.setItemStack(new ItemStack(Material.AIR));
 
         Float hVelocity = loot.getEntity().getEntityProperties().horizontalVelocity();
-        if(hVelocity == null) hVelocity = 1.2f;
+        if (hVelocity == null) hVelocity = 1.2f;
 
         Float vVelocity = loot.getEntity().getEntityProperties().verticalVelocity();
-        if(vVelocity == null) vVelocity = 1.3f;
+        if (vVelocity == null) vVelocity = 1.3f;
 
         Vector vector = player.getLocation().subtract(location).toVector().multiply(hVelocity - 1);
         vector.setY((vector.getY() + 0.2) * vVelocity);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/LootHandler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/LootHandler.java
@@ -120,11 +120,13 @@ public abstract class LootHandler {
         giveXp(player, loot, source, skill);
     }
 
-    protected void giveFishingEntityLoot(Player player, EntityLoot loot, PlayerFishEvent event, @Nullable XpSource source, Skill skill, LootDropEvent.Cause cause, LootTable table) {
+    protected void giveFishingEntityLoot(Player player, EntityLoot loot, PlayerFishEvent event, @Nullable XpSource source, Skill skill, LootDropEvent.Cause cause) {
         if (!(event.getCaught() instanceof Item itemEntity)) return;
 
         Location location = event.getHook().getLocation();
         Entity entity = loot.getEntity().spawnEntity(plugin, event.getHook().getLocation());
+
+        if (entity == null) return;
 
         LootDropEvent dropEvent = new LootDropEvent(player, plugin.getUser(player).toApi(), entity, event.getHook().getLocation(), cause);
         Bukkit.getPluginManager().callEvent(dropEvent);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/LootHandler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/handler/LootHandler.java
@@ -15,6 +15,7 @@ import dev.aurelium.auraskills.api.loot.LootContext;
 import dev.aurelium.auraskills.bukkit.loot.context.MobContext;
 import dev.aurelium.auraskills.bukkit.loot.context.SourceContext;
 import dev.aurelium.auraskills.bukkit.loot.type.CommandLoot;
+import dev.aurelium.auraskills.bukkit.loot.type.EntityLoot;
 import dev.aurelium.auraskills.bukkit.loot.type.ItemLoot;
 import dev.aurelium.auraskills.bukkit.util.ItemUtils;
 import dev.aurelium.auraskills.common.commands.CommandExecutor;
@@ -26,9 +27,12 @@ import dev.aurelium.slate.text.TextFormatter;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.inventory.ItemStack;
@@ -112,6 +116,36 @@ public abstract class LootHandler {
         if (dropEvent.isCancelled()) return;
 
         itemEntity.setItemStack(dropEvent.getItem());
+        attemptSendMessage(player, loot);
+        giveXp(player, loot, source, skill);
+    }
+
+    protected void giveFishingEntityLoot(Player player, EntityLoot loot, PlayerFishEvent event, @Nullable XpSource source, Skill skill, LootDropEvent.Cause cause, LootTable table) {
+        if (!(event.getCaught() instanceof Item itemEntity)) return;
+
+        Location location = event.getHook().getLocation();
+        Entity entity = loot.getEntity().spawnEntity(plugin, event.getHook().getLocation());
+
+        LootDropEvent dropEvent = new LootDropEvent(player, plugin.getUser(player).toApi(), entity, event.getHook().getLocation(), cause);
+        Bukkit.getPluginManager().callEvent(dropEvent);
+
+        if (dropEvent.isCancelled()) {
+            loot.getEntity().removeEntity(entity);
+            return;
+        }
+
+        itemEntity.setItemStack(new ItemStack(Material.AIR));
+
+        Float hVelocity = loot.getEntity().getEntityProperties().horizontalVelocity();
+        if(hVelocity == null) hVelocity = 1.2f;
+
+        Float vVelocity = loot.getEntity().getEntityProperties().verticalVelocity();
+        if(vVelocity == null) vVelocity = 1.3f;
+
+        Vector vector = player.getLocation().subtract(location).toVector().multiply(hVelocity - 1);
+        vector.setY((vector.getY() + 0.2) * vVelocity);
+        entity.setVelocity(vector);
+
         attemptSendMessage(player, loot);
         giveXp(player, loot, source, skill);
     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomEntityParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomEntityParser.java
@@ -4,5 +4,7 @@ import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public interface CustomEntityParser extends CustomParser {
+
     EntitySupplier getEntitySupplier(ConfigurationNode config);
+
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomEntityParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomEntityParser.java
@@ -1,0 +1,8 @@
+package dev.aurelium.auraskills.bukkit.loot.parser;
+
+import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
+import org.spongepowered.configurate.ConfigurationNode;
+
+public interface CustomEntityParser extends CustomParser {
+    EntitySupplier getEntitySupplier(ConfigurationNode config);
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomItemParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomItemParser.java
@@ -3,10 +3,6 @@ package dev.aurelium.auraskills.bukkit.loot.parser;
 import org.bukkit.inventory.ItemStack;
 import org.spongepowered.configurate.ConfigurationNode;
 
-public interface CustomItemParser {
-
-    boolean shouldUseParser(ConfigurationNode config);
-
+public interface CustomItemParser extends CustomParser {
     ItemStack parseCustomItem(ConfigurationNode config);
-
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomItemParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomItemParser.java
@@ -4,5 +4,7 @@ import org.bukkit.inventory.ItemStack;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public interface CustomItemParser extends CustomParser {
+
     ItemStack parseCustomItem(ConfigurationNode config);
+
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomParser.java
@@ -3,5 +3,7 @@ package dev.aurelium.auraskills.bukkit.loot.parser;
 import org.spongepowered.configurate.ConfigurationNode;
 
 public interface CustomParser {
+
     boolean shouldUseParser(ConfigurationNode config);
+
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/CustomParser.java
@@ -1,0 +1,7 @@
+package dev.aurelium.auraskills.bukkit.loot.parser;
+
+import org.spongepowered.configurate.ConfigurationNode;
+
+public interface CustomParser {
+    boolean shouldUseParser(ConfigurationNode config);
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/EntityLootParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/EntityLootParser.java
@@ -1,0 +1,38 @@
+package dev.aurelium.auraskills.bukkit.loot.parser;
+
+import dev.aurelium.auraskills.api.loot.Loot;
+import dev.aurelium.auraskills.api.loot.LootParser;
+import dev.aurelium.auraskills.api.loot.LootParsingContext;
+import dev.aurelium.auraskills.bukkit.loot.LootManager;
+import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
+import dev.aurelium.auraskills.bukkit.loot.type.EntityLoot;
+import dev.aurelium.auraskills.common.util.data.Validate;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+
+
+public class EntityLootParser implements LootParser {
+    protected final LootManager manager;
+
+    public EntityLootParser(LootManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public Loot parse(LootParsingContext context, ConfigurationNode config) throws SerializationException {
+        String entityType = config.node("entity").getString();
+        Validate.notNull(entityType, "Entity loot must specify an entity type");
+
+        EntitySupplier entity = null;
+        for (CustomEntityParser parser : manager.getCustomEntityParsers()) {
+            if (parser.shouldUseParser(config)) {
+                entity = parser.getEntitySupplier(config);
+                break;
+            }
+        }
+
+        Validate.notNull(entity, "Couldn't parse entity loot with entity type: " + entityType);
+
+        return new EntityLoot(context.parseValues(config), entity);
+    }
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/EntityLootParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/EntityLootParser.java
@@ -10,7 +10,6 @@ import dev.aurelium.auraskills.common.util.data.Validate;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
-
 public class EntityLootParser implements LootParser {
 
     protected final LootManager manager;

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/EntityLootParser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/parser/EntityLootParser.java
@@ -12,6 +12,7 @@ import org.spongepowered.configurate.serialize.SerializationException;
 
 
 public class EntityLootParser implements LootParser {
+
     protected final LootManager manager;
 
     public EntityLootParser(LootManager manager) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/type/EntityLoot.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/type/EntityLoot.java
@@ -5,6 +5,7 @@ import dev.aurelium.auraskills.api.loot.LootValues;
 import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
 
 public class EntityLoot extends Loot {
+    
     private final EntitySupplier entity;
 
     public EntityLoot(LootValues values, EntitySupplier entity) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/type/EntityLoot.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/loot/type/EntityLoot.java
@@ -1,0 +1,18 @@
+package dev.aurelium.auraskills.bukkit.loot.type;
+
+import dev.aurelium.auraskills.api.loot.Loot;
+import dev.aurelium.auraskills.api.loot.LootValues;
+import dev.aurelium.auraskills.bukkit.loot.entity.EntitySupplier;
+
+public class EntityLoot extends Loot {
+    private final EntitySupplier entity;
+
+    public EntityLoot(LootValues values, EntitySupplier entity) {
+        super(values);
+        this.entity = entity;
+    }
+
+    public EntitySupplier getEntity() {
+        return entity;
+    }
+}


### PR DESCRIPTION
This PR adds a new entity loot type for fishing (or it can be added to other loot tables as well, it just didn't really make sense).
The caught entity can be a vanilla entity (typically a mob) or a MythicMobs using the `mythicmobs:` prefix. Entity health, damage, and level can also be configured.

The vertical and horizontal velocities are also configurable for fishing but already have default values.

Example configuration in `fishing.yml`:

```yml
type: fishing
pools:
  rare:
    base_chance: 100
    selection_priority: 1
    loot:
      - type: entity
        entity: zombie
        name: "&6My Little Zombie"
        weight: 50
        health: 100
        damage: 100
        velocity:
          horizontal: 1.2
          vertical: 1.3
      - type: entity
        entity: mythicmobs:SkeletonKing
        weight: 50
        level: 10
```