### PR TITLE
Reload modifiers on remove a tick later

### DIFF
--- a/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/user/User.java
@@ -4,6 +4,7 @@ import dev.aurelium.auraskills.api.ability.Ability;
 import dev.aurelium.auraskills.api.ability.AbstractAbility;
 import dev.aurelium.auraskills.api.mana.ManaAbility;
 import dev.aurelium.auraskills.api.registry.NamespacedId;
+import dev.aurelium.auraskills.api.skill.Multiplier;
 import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.api.stat.Stat;
 import dev.aurelium.auraskills.api.stat.StatModifier;
@@ -18,7 +19,6 @@ import dev.aurelium.auraskills.common.api.implementation.ApiSkillsUser;
 import dev.aurelium.auraskills.common.config.Option;
 import dev.aurelium.auraskills.common.jobs.JobsBatchData;
 import dev.aurelium.auraskills.common.mana.ManaAbilityData;
-import dev.aurelium.auraskills.api.skill.Multiplier;
 import dev.aurelium.auraskills.common.ui.ActionBarType;
 import dev.aurelium.auraskills.common.util.data.KeyIntPair;
 import net.kyori.adventure.text.Component;
@@ -117,7 +117,7 @@ public abstract class User {
         for (Map.Entry<Skill, Integer> entry : skillLevels.entrySet()) {
             if (entry.getKey().isEnabled()) {
                 sum += entry.getValue();
-                numEnabled ++;
+                numEnabled++;
             }
         }
         return sum / (double) numEnabled;
@@ -298,7 +298,8 @@ public abstract class User {
         map.remove(name);
         // Reloads modifier type
         if (reload) {
-            plugin.getStatManager().reload(this, modifier.type());
+            // Run a tick later to prevent invalid removing then readding of the same modifier by 3rd parties
+            plugin.getScheduler().executeSync(() -> plugin.getStatManager().reload(this, modifier.type()));
         }
         return true;
     }
@@ -510,6 +511,7 @@ public abstract class User {
 
     /**
      * Checks if the profile has not had any changes since creation
+     *
      * @return True if profile has not been modified, false if player has leveled profile
      */
     public boolean isBlankProfile() {


### PR DESCRIPTION
This fixes compatibility issues with libreforge (eco).
I don't see any places where this would cause any problems internally (though I might be wrong).
There is a strange effect when libreforge `add_stat` effect for the health stat causes the player taking damage non stop, because the effect gets reloaded on every inventory event or even on health regen events.

Libreforge reload looks like this:
- call onDisable on the effect -> removes the health modifier which causes here an instant reload which resets the health
- call onEnable on the effect -> adds back the modifier which causes here an instant reload which increases the max health via vanilla attribute modifiers.
- This libreforge effect reload thing will be called everytime a meaningful inventory event or health regen event or anything like that happens. This makes the `add_stat` effect unusable with the health stat.

Other possible resolutions from the libreforge side of things:
- Make the Effect override `shouldReload` with `false`. This is also pretty easy but probably if the amount is an expression that can change, well it won't anymore.
- Make effect reloading not dumb. It is already present in the BonusHealth AttributeEffect that removing the reload method and call disable and then enable wasn't the best idea. Reload is a reload for a reason. 

I will make this PR a draft. I don't actually want this to be merged since this is very much fixable from the libreforge side and I think it should be fixed there.

In the meantime if anyone really needs a quick fix, build this PR, it will fix the health issue, but use it at your own risk. I haven't tested every internal behavior so it might cause issues. Not likely, but there is always a chance.