### PR TITLE
Respect cancelled drops

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/BlockLeveler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/BlockLeveler.java
@@ -49,7 +49,7 @@ public class BlockLeveler extends SourceLeveler {
         Player player = event.getPlayer();
         Block block = event.getBlock();
 
-        handleBreak(player, block, event, trait -> trait.getUniqueDrops(block, player));
+        handleBreak(player, block, event, trait -> event.isDropItems() ? trait.getUniqueDrops(block, player) : Collections.emptySet());
     }
 
     public void handleBreak(Player player, Block block, Cancellable event, Function<GatheringLuckTraits, Set<ItemStack>> dropFunction) {


### PR DESCRIPTION
Currently if other plugins cancel block drops, some drop will still happen due to the fact that an ability is doubling the drop. This pr fixes that and if other plugins cancel the drops then AuraSkills will not try to drop anything