### PR TITLE
Add option to disable optimized multiplier permission lookup

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
@@ -32,14 +32,14 @@ public class BukkitLuckPermsHook extends LuckPermsHook implements Listener {
 
     private final String prefix = "auraskills.multiplier.";
     private final Map<UUID, Set<String>> permissionCache = new ConcurrentHashMap<>();
-    private final boolean optimizePermissionLookup;
+    private final boolean usePermissionCache;
 
     public BukkitLuckPermsHook(AuraSkillsPlugin plugin, ConfigurationNode config) {
         super(plugin, config);
 
-        this.optimizePermissionLookup = config.node("use_permission_cache").getBoolean(true);
+        this.usePermissionCache = config.node("use_permission_cache").getBoolean(true);
 
-        if (!this.optimizePermissionLookup) return;
+        if (!this.usePermissionCache) return;
 
         luckPerms.getEventBus().subscribe(NodeAddEvent.class,
                 event -> handleEvent(event.getNode(), event.getTarget()));
@@ -48,8 +48,8 @@ public class BukkitLuckPermsHook extends LuckPermsHook implements Listener {
                 event -> handleEvent(event.getNode(), event.getTarget()));
     }
 
-    public boolean optimizePermissionLookup() {
-        return optimizePermissionLookup;
+    public boolean usePermissionCache() {
+        return usePermissionCache;
     }
 
     private void handleEvent(Node node, PermissionHolder target) {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
@@ -37,7 +37,7 @@ public class BukkitLuckPermsHook extends LuckPermsHook implements Listener {
     public BukkitLuckPermsHook(AuraSkillsPlugin plugin, ConfigurationNode config) {
         super(plugin, config);
 
-        this.optimizePermissionLookup = getConfig().node("optimize_permission_lookup").getBoolean();
+        this.optimizePermissionLookup = config.node("optimize_permission_lookup").getBoolean(true);
 
         if (!this.optimizePermissionLookup) return;
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
@@ -37,7 +37,7 @@ public class BukkitLuckPermsHook extends LuckPermsHook implements Listener {
     public BukkitLuckPermsHook(AuraSkillsPlugin plugin, ConfigurationNode config) {
         super(plugin, config);
 
-        this.optimizePermissionLookup = config.node("optimize_permission_lookup").getBoolean(true);
+        this.optimizePermissionLookup = config.node("use_permission_cache").getBoolean(true);
 
         if (!this.optimizePermissionLookup) return;
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/BukkitLuckPermsHook.java
@@ -32,15 +32,24 @@ public class BukkitLuckPermsHook extends LuckPermsHook implements Listener {
 
     private final String prefix = "auraskills.multiplier.";
     private final Map<UUID, Set<String>> permissionCache = new ConcurrentHashMap<>();
+    private final boolean optimizePermissionLookup;
 
     public BukkitLuckPermsHook(AuraSkillsPlugin plugin, ConfigurationNode config) {
         super(plugin, config);
+
+        this.optimizePermissionLookup = getConfig().node("optimize_permission_lookup").getBoolean();
+
+        if (!this.optimizePermissionLookup) return;
 
         luckPerms.getEventBus().subscribe(NodeAddEvent.class,
                 event -> handleEvent(event.getNode(), event.getTarget()));
 
         luckPerms.getEventBus().subscribe(NodeRemoveEvent.class,
                 event -> handleEvent(event.getNode(), event.getTarget()));
+    }
+
+    public boolean optimizePermissionLookup() {
+        return optimizePermissionLookup;
     }
 
     private void handleEvent(Node node, PermissionHolder target) {
@@ -56,7 +65,7 @@ public class BukkitLuckPermsHook extends LuckPermsHook implements Listener {
                     () -> {
                         Player player = Bukkit.getPlayer(user.getUniqueId());
                         // In case if someone logs out in that 500 ms timeframe
-                        if(player == null || !player.isOnline()) return;
+                        if (player == null || !player.isOnline()) return;
                         permissionCache.put(user.getUniqueId(), getMultiplierPermissions(user.getUniqueId()));
                     },
                     500,

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/user/BukkitUser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/user/BukkitUser.java
@@ -66,7 +66,7 @@ public class BukkitUser extends User {
         double multiplier = 0.0;
 
         if (plugin.getHookManager().isRegistered(BukkitLuckPermsHook.class)
-                && plugin.getHookManager().getHook(BukkitLuckPermsHook.class).optimizePermissionLookup()) {
+                && plugin.getHookManager().getHook(BukkitLuckPermsHook.class).usePermissionCache()) {
             Set<String> permissions = plugin.getHookManager().getHook(BukkitLuckPermsHook.class).getMultiplierPermissions(player);
             for (String permission : permissions) {
                 multiplier += getMultiplierFromPermission(permission, skill);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/user/BukkitUser.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/user/BukkitUser.java
@@ -65,7 +65,8 @@ public class BukkitUser extends User {
         }
         double multiplier = 0.0;
 
-        if (plugin.getHookManager().isRegistered(BukkitLuckPermsHook.class)) {
+        if (plugin.getHookManager().isRegistered(BukkitLuckPermsHook.class)
+                && plugin.getHookManager().getHook(BukkitLuckPermsHook.class).optimizePermissionLookup()) {
             Set<String> permissions = plugin.getHookManager().getHook(BukkitLuckPermsHook.class).getMultiplierPermissions(player);
             for (String permission : permissions) {
                 multiplier += getMultiplierFromPermission(permission, skill);
@@ -169,7 +170,8 @@ public class BukkitUser extends User {
                     if (value > highestLimit) {
                         highestLimit = value;
                     }
-                } catch (NumberFormatException ignored) {}
+                } catch (NumberFormatException ignored) {
+                }
             }
         }
         return highestLimit;

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -34,7 +34,7 @@ hooks:
     enabled: true
   LuckPerms:
     enabled: true
-    optimize_permission_lookup: true
+    use_permission_cache: true
   Oraxen:
     enabled: true
   PlaceholderAPI:

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -25,7 +25,7 @@ sql:
     max_lifetime: 1800000
     keepalive_time: 0
 default_language: en
-languages: [en, es, fr, de, zh-CN, zh-TW, pt-BR, it, cs, pl, uk, ko, nl, ja, ru, id, vi, tr, fi, th]
+languages: [ en, es, fr, de, zh-CN, zh-TW, pt-BR, it, cs, pl, uk, ko, nl, ja, ru, id, vi, tr, fi, th ]
 try_detect_client_language: false
 hooks:
   HolographicDisplays:
@@ -34,6 +34,7 @@ hooks:
     enabled: true
   LuckPerms:
     enabled: true
+    optimize_permission_lookup: true
   Oraxen:
     enabled: true
   PlaceholderAPI:
@@ -168,7 +169,7 @@ damage_holograms:
   colors:
     default: gray
     critical:
-      digits: [white, yellow, gold, red, dark_red, dark_purple, light_purple, blue, dark_blue]
+      digits: [ white, yellow, gold, red, dark_red, dark_purple, light_purple, blue, dark_blue ]
 leaderboards:
   update_period: 6000
   update_delay: 6000
@@ -228,10 +229,10 @@ requirement:
     prevent_weapon_use: true
     prevent_block_place: true
     prevent_interact: true
-    global: []
+    global: [ ]
   armor:
     prevent_armor_equip: true
-    global: []
+    global: [ ]
 critical:
   enabled:
     sword: true


### PR DESCRIPTION
Luckperms doesn't have any event for permission changes based on the permission nodes contexts.
This means the current cache won't take into account when a multiplier is added/removed based on contexts.
For example, if you use ExtraContexts, or any other built-in LP contexts the cache probably wouldn't work.
I didn't want to remove the entire feature, since it is probably useful for many large servers. Most people only use the server context which doesn't change on the same server. Instead, I made a config option to disable the feature if necessary.