### PR TITLE
Item resolvers

### DIFF
--- a/api/src/main/java/dev/aurelium/auraskills/api/registry/NamespacedId.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/registry/NamespacedId.java
@@ -7,10 +7,12 @@ public class NamespacedId {
 
     public static final String AURASKILLS = "auraskills";
     private final String namespace;
+    private final String originalKey;
     private final String key;
 
     private NamespacedId(String namespace, String key) {
         this.namespace = namespace.toLowerCase(Locale.ROOT);
+        this.originalKey = key;
         this.key = key.toLowerCase(Locale.ROOT);
     }
 
@@ -31,6 +33,15 @@ public class NamespacedId {
      */
     public String getKey() {
         return key;
+    }
+
+    /**
+     * Gets the original key portion of the NamespacedId, which is the key in the case it was created with.
+     *
+     * @return the original key
+     */
+    public String getOriginalKey() {
+        return originalKey;
     }
 
     /**

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/mythicmobs/MythicMobsHook.java
@@ -32,9 +32,16 @@ public class MythicMobsHook extends Hook implements Listener {
         this.plugin = plugin;
         this.damageHandler = new DamageHandler();
 
+        registerItemProvider();
+
         // Wait for loot manager to be created, but add parser before it is loaded
         plugin.getScheduler().executeSync(() ->
                 plugin.getLootTableManager().getLootManager().registerCustomEntityParser(new MythicEntityLootParser(plugin)));
+    }
+
+    private void registerItemProvider() {
+        plugin.getItemRegistry().registerExternalItemProvider("mythicmobs",
+                (id) -> MythicBukkit.inst().getItemManager().getItemStack(id));
     }
 
     @EventHandler

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/BukkitItemRegistry.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/BukkitItemRegistry.java
@@ -58,9 +58,14 @@ public class BukkitItemRegistry implements ItemRegistry {
         ItemStack item = items.get(key);
         if (item != null) {
             return item.clone();
-        } else {
-            return null;
         }
+
+        ExternalItemProvider provider = externalItemProviders.get(key.getNamespace());
+        if(provider != null) {
+            return provider.getItem(key.getKey());
+        }
+
+        return null;
     }
 
     public Map<NamespacedId, ItemStack> getItems() {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/BukkitItemRegistry.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/BukkitItemRegistry.java
@@ -61,8 +61,8 @@ public class BukkitItemRegistry implements ItemRegistry {
         }
 
         ExternalItemProvider provider = externalItemProviders.get(key.getNamespace());
-        if(provider != null) {
-            return provider.getItem(key.getKey());
+        if (provider != null) {
+            return provider.getItem(key.getOriginalKey());
         }
 
         return null;


### PR DESCRIPTION
Item registry now returns external plugin items as well from the registered providers, meaning these items can be used in rewards and in loot pools. (And everywhere that uses BukkitItemRegistry#getItem)
I had to store the original key in the NamespacedId as well since plugins usually use case sensitive IDs. 
Item resolver for MM is also added.