### PR TITLE
Fix/shield blocking

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/DamageLeveler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/DamageLeveler.java
@@ -9,7 +9,6 @@ import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.common.source.SourceTypes;
 import dev.aurelium.auraskills.common.user.User;
 import org.bukkit.Location;
-import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;


### PR DESCRIPTION
When blocking the damage xp is not gained regardless if the hit was actually blocked, so for instance an entity attacking someone from the back, hence not activating the shield, will not earn defense XP.

As I couldn't find a way to check if the attack was shield blocked the only way to go about it is checking if the player yaw allows blocking, so redoing some internal calculations.

Requires testing.