### PR TITLE
Modified reloadModifiers() to wrap the content in a delayed task to fix a bug

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     compileOnly("com.github.Slimefun:Slimefun4:RC-37")
     compileOnly("com.mojang:authlib:1.5.25")
     compileOnly("io.lumine:Mythic-Dist:5.6.1")
-    compileOnly("io.th0rgal:oraxen:1.173.0")
+    compileOnly("io.th0rgal:oraxen:1.176.0")
 }
 
 val compiler = javaToolchains.compilerFor {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/BukkitLevelManager.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/level/BukkitLevelManager.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class BukkitLevelManager extends LevelManager {
 
@@ -114,9 +115,13 @@ public class BukkitLevelManager extends LevelManager {
 
     @Override
     public void reloadModifiers(User user) {
-        Player player = ((BukkitUser) user).getPlayer();
-        if (player != null) {
-            plugin.getModifierManager().reloadPlayer(player);
-        }
+        plugin.getScheduler().scheduleSync(() -> {
+            Player player = ((BukkitUser) user).getPlayer();
+            if (player != null) {
+                double currentHealth = player.getHealth();
+                plugin.getModifierManager().reloadPlayer(player);
+                player.setHealth(currentHealth);
+            }
+        }, 5L, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
If a hit that should kill you with your normal health, let's say 100 damage, but you have 500 health from the plugin for example and with this hit you level up a skill, calling reloadModifiers() is bugged and kills you.   If the damage is not lethal, the damage is also miscalculated and you are left with only 20hp.

A video showing the bug:

https://github.com/user-attachments/assets/be341e33-52b6-4f84-ba96-c92ffd1564ac

The bug "patched":

https://github.com/user-attachments/assets/0f8d2895-d9bf-4175-afe7-5302ebfcb26f


