### PR TITLE
ci: Run Gradle build on all pull requests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
This PR has CI run on pull requests, irrespective of the base branch selected.