### PR TITLE
fix: Change BlockBreakEvent priority to LOWEST to prevent conflicts

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/requirement/RequirementListener.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/requirement/RequirementListener.java
@@ -93,7 +93,7 @@ public class RequirementListener implements Listener {
                 "{requirements}", requirementsString.toString()));
     }
 
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent event) {
         if (event.isCancelled()) return;
         if (plugin.configBoolean(Option.REQUIREMENT_ITEM_PREVENT_TOOL_USE)) {


### PR DESCRIPTION
Changed the event priority of BlockBreakEvent in RequirementListener from HIGHEST to LOWEST to ensure requirements are checked before other plugins process the event. This fixes an issue where plugins using NORMAL priority (like Nexo's auto-smelt) would process drops even when the event was later cancelled due to insufficient skill requirements.

- Changed @EventHandler priority to EventPriority.LOWEST- Ensures event cancellation happens before other plugins process drops- Maintains compatibility with plugins that respect event cancellation

TLDR; 
Fixes this https://youtu.be/rx10iCL8rS0