### PR TITLE
Missing fillItem

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/LevelProgressionMenu.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/LevelProgressionMenu.java
@@ -85,6 +85,7 @@ public class LevelProgressionMenu {
         menu.item("previous_page", globalItems::previousPage);
         menu.item("next_page", globalItems::nextPage);
         menu.item("close", globalItems::close);
+        menu.fillItem(globalItems::fill);
 
         var skillItem = new SkillItem(plugin);
         skillItem.buildComponents(menu);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/StatInfoMenu.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/menus/StatInfoMenu.java
@@ -67,7 +67,9 @@ public class StatInfoMenu {
         menu.replace("color", p -> stat(p).getColor(p.locale()));
         menu.replace("stat_name", p -> stat(p).getDisplayName(p.locale(), false));
 
+        var globalItems = new GlobalItems(plugin);
         menu.item("back", item -> getBackItem(plugin, item));
+        menu.fillItem(globalItems::fill);
 
         menu.template("stat", Stat.class, template -> {
             template.replace("stat_desc", p -> stat(p).getDescription(p.locale(), false));


### PR DESCRIPTION
Two menus are missing the fillItem function call. Resulting in fill items showing their tooltips.
This should fix the issue that's (vaguely) mentioned in #389 which seems to impact two menus.