### PR TITLE
Potential fix for #392 (Global Requirements in Disabled Worlds)

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/requirement/RequirementListener.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/requirement/RequirementListener.java
@@ -43,6 +43,7 @@ public class RequirementListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEquip(ArmorEquipEvent event) {
         if (event.isCancelled()) return;
+        if (plugin.getWorldManager().isInDisabledWorld(event.getPlayer().getLocation())) return;
         Player player = event.getPlayer();
         ItemStack item = event.getNewArmorPiece();
         if (item == null) {
@@ -96,6 +97,7 @@ public class RequirementListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent event) {
         if (event.isCancelled()) return;
+        if (plugin.getWorldManager().isInDisabledWorld(event.getPlayer().getLocation())) return;
         if (plugin.configBoolean(Option.REQUIREMENT_ITEM_PREVENT_TOOL_USE)) {
             Player player = event.getPlayer();
             ItemStack item = player.getInventory().getItemInMainHand();
@@ -110,6 +112,7 @@ public class RequirementListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onPlace(BlockPlaceEvent event) {
         if (event.isCancelled()) return;
+        if (plugin.getWorldManager().isInDisabledWorld(event.getPlayer().getLocation())) return;
         if (plugin.configBoolean(Option.REQUIREMENT_ITEM_PREVENT_BLOCK_PLACE)) {
             Player player = event.getPlayer();
             ItemStack item = event.getItemInHand();
@@ -124,6 +127,7 @@ public class RequirementListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onHarvest(PlayerHarvestBlockEvent event) {
         if (event.isCancelled()) return;
+        if (plugin.getWorldManager().isInDisabledWorld(event.getPlayer().getLocation())) return;
 
         checkBlockRequirements(event.getPlayer(), event.getHarvestedBlock().getType(), event);
     }
@@ -133,6 +137,7 @@ public class RequirementListener implements Listener {
         if (event.isCancelled()) return;
         if (plugin.configBoolean(Option.REQUIREMENT_ITEM_PREVENT_WEAPON_USE)) {
             if (event.getDamager() instanceof Player player) {
+                if (plugin.getWorldManager().isInDisabledWorld(player.getLocation())) return;
                 ItemStack item = player.getInventory().getItemInMainHand();
                 if (item.getType() == Material.AIR) return;
                 checkItemRequirements(player, item, event);
@@ -145,6 +150,7 @@ public class RequirementListener implements Listener {
         if (event.isCancelled()) return;
         if (!plugin.configBoolean(Option.REQUIREMENT_ITEM_PREVENT_WEAPON_USE)) return;
         if (!(event.getEntity() instanceof Player player)) return;
+        if (plugin.getWorldManager().isInDisabledWorld(player.getLocation())) return;
 
         ItemStack item = event.getBow();
         if (item == null) return;
@@ -155,6 +161,7 @@ public class RequirementListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onInteract(PlayerInteractEvent event) {
+        if (plugin.getWorldManager().isInDisabledWorld(event.getPlayer().getLocation())) return;
         if (event.useItemInHand() == Event.Result.DENY) return;
         if (!plugin.configBoolean(Option.REQUIREMENT_ITEM_PREVENT_INTERACT)) return;
 


### PR DESCRIPTION
Potential fix for Global Requirements not honoring Disabled Worlds. Which results in restrictions being enforced in worlds where AuraSkills should be disabled. See issue #392 for details as described by @Zhentox.
