### PR TITLE
Fixed issue with off-hand bonuses not being applied

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/ItemListener.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/ItemListener.java
@@ -51,20 +51,28 @@ public class ItemListener implements Listener {
         if (!plugin.configBoolean(Option.MODIFIER_ITEM_ENABLE_OFF_HAND)) {
             return;
         }
+
         Player player = event.getPlayer();
         User user = plugin.getUser(player);
+        Set<ReloadableIdentifier> toReload = new HashSet<>();
 
         // Get items switched
         ItemStack itemOffHand = event.getOffHandItem();
+        ItemStack itemMainHand = event.getMainHandItem();
+
+        // Unload all existing hand effects for a short time to prevent overriding effects
+        toReload.addAll(stateManager.changeItemInSlot(user, player, new ItemStack(Material.AIR), EquipmentSlot.OFF_HAND, false, false, false));
+        toReload.addAll(stateManager.changeItemInSlot(user, player, new ItemStack(Material.AIR), EquipmentSlot.HAND, false, false, false));
+
         if (itemOffHand == null) {
             itemOffHand = new ItemStack(Material.AIR);
         }
-        ItemStack itemMainHand = event.getMainHandItem();
+
         if (itemMainHand == null) {
             itemMainHand = new ItemStack(Material.AIR);
         }
 
-        Set<ReloadableIdentifier> toReload = new HashSet<>();
+        // Now that all effects are unloaded, we can reload the items which will apply the new effects without overriding each other
 
         toReload.addAll(stateManager.changeItemInSlot(user, player, itemOffHand, EquipmentSlot.OFF_HAND, false, false, false));
         toReload.addAll(stateManager.changeItemInSlot(user, player, itemMainHand, EquipmentSlot.HAND, false, false, false));


### PR DESCRIPTION
This PR fixes the issue opposed in the post on [Discord](https://discord.com/channels/732657582313046027/1392982523876872294) where Valor is not applied in the offhand.

**The issue**:
The issue itself was in the `PlayerSwapItemsEvent`, where the call-order of `#changeItemInSlot` caused the indeed applied valor effect for the offhand to later be unloaded, due to the system saying, that the axe in the mainhand is gone, which caused it to immediately remove it again. Since the mainhand would always be updated second, it has the final say, meaning swapping it back made the appearance as if it only worked in the mainhand.

**The fix**:
Since this should have affected all other bonuses too, I have decided to first unload all effects and then load all effects back in, thinking the small time without bonuses should not be noticeable. I previously had thought of adding an `else`-section after the `if`-statements but my head is currently not able to comprehend whether this has the same outcome or not.

**Known issues**:
For valor, I don't know why exactly but when having the axe in the mainhand, I have, e.g., 59 strength, while only 58 in the offhand.
<img width="407" height="416" alt="image" src="https://github.com/user-attachments/assets/04831460-1367-46aa-afa4-cf003fd121e5" />
<img width="510" height="395" alt="image" src="https://github.com/user-attachments/assets/566220a6-7c40-439a-80f8-30a1097cfa1f" />
