### PR TITLE
Added blockTrigger collect

### DIFF
--- a/api/src/main/java/dev/aurelium/auraskills/api/source/type/BlockXpSource.java
+++ b/api/src/main/java/dev/aurelium/auraskills/api/source/type/BlockXpSource.java
@@ -100,7 +100,8 @@ public interface BlockXpSource extends XpSource {
     enum BlockTriggers {
 
         BREAK,
-        INTERACT
+        INTERACT,
+        COLLECT
 
     }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
@@ -24,6 +24,7 @@ import dev.aurelium.auraskills.bukkit.item.*;
 import dev.aurelium.auraskills.bukkit.jobs.JobsListener;
 import dev.aurelium.auraskills.bukkit.leaderboard.BukkitLeaderboardExclusion;
 import dev.aurelium.auraskills.bukkit.level.BukkitLevelManager;
+import dev.aurelium.auraskills.bukkit.listeners.BlockInteractions;
 import dev.aurelium.auraskills.bukkit.listeners.CriticalHandler;
 import dev.aurelium.auraskills.bukkit.listeners.DamageListener;
 import dev.aurelium.auraskills.bukkit.listeners.PlayerDeath;
@@ -443,6 +444,7 @@ public class AuraSkills extends JavaPlugin implements AuraSkillsPlugin {
         PluginManager pm = getServer().getPluginManager();
         pm.registerEvents(new DamageListener(this), this);
         pm.registerEvents(new CriticalHandler(this), this);
+        pm.registerEvents(new BlockInteractions(this), this);
         pm.registerEvents(new BlockLootHandler(this), this);
         pm.registerEvents(new FishingLootHandler(this), this);
         pm.registerEvents(new MobLootHandler(this), this);

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/listeners/BlockInteractions.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/listeners/BlockInteractions.java
@@ -1,0 +1,42 @@
+package dev.aurelium.auraskills.bukkit.listeners;
+
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFertilizeEvent;
+import org.bukkit.event.block.CauldronLevelChangeEvent;
+import org.bukkit.event.block.CauldronLevelChangeEvent.ChangeReason;
+import org.bukkit.metadata.FixedMetadataValue;
+
+import java.util.*;
+
+public class BlockInteractions implements Listener {
+
+    private final AuraSkills plugin;
+    private final Set<ChangeReason> cauldronLevelChangeReasons = Set.of(
+            CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY,
+            CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY
+    );
+
+    public BlockInteractions(AuraSkills plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockFertilize(BlockFertilizeEvent event) {
+        Block block = event.getBlock();
+        block.setMetadata("fertilized", new FixedMetadataValue(plugin, true));
+    }
+
+    @EventHandler
+    public void onCauldronFill(CauldronLevelChangeEvent event) {
+        CauldronLevelChangeEvent.ChangeReason reason = event.getReason();
+        if (cauldronLevelChangeReasons.contains(reason)) {
+            Block cauldron = event.getBlock();
+            cauldron.setMetadata("filledManually", new FixedMetadataValue(plugin, true));
+        }
+    }
+
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/listeners/BlockInteractions.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/listeners/BlockInteractions.java
@@ -17,8 +17,7 @@ public class BlockInteractions implements Listener {
     private final AuraSkills plugin;
     private final Set<ChangeReason> cauldronLevelChangeReasons = Set.of(
             CauldronLevelChangeEvent.ChangeReason.BOTTLE_EMPTY,
-            CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY
-    );
+            CauldronLevelChangeEvent.ChangeReason.BUCKET_EMPTY);
 
     public BlockInteractions(AuraSkills plugin) {
         this.plugin = plugin;

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/BlockLeveler.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/source/BlockLeveler.java
@@ -38,20 +38,17 @@ public class BlockLeveler extends SourceLeveler {
 
     private final Set<Material> collectShearBlocks = Set.of(
             Material.BEEHIVE,
-            Material.BEE_NEST
-    );
+            Material.BEE_NEST);
     private final Set<Material> collectBottleBlocks = Set.of(
             Material.BEEHIVE,
             Material.BEE_NEST,
             Material.CAULDRON,
-            Material.WATER_CAULDRON
-    );
+            Material.WATER_CAULDRON);
     private final Set<Material> collectBucketBlocks = Set.of(
             Material.CAULDRON,
             Material.WATER_CAULDRON,
             Material.LAVA_CAULDRON,
-            Material.POWDER_SNOW_CAULDRON
-    );
+            Material.POWDER_SNOW_CAULDRON);
 
     public BlockLeveler(AuraSkills plugin) {
         super(plugin, SourceTypes.BLOCK);


### PR DESCRIPTION
This allows blocks like beehives/-nests and cauldrons to be used as a source. When trigger is set to "collect" players can use shears (beehive/-nest) or bottles (all three) or buckets (cauldrons) to collect resources and get rewarded.

Interact would otherwise reward for any click made, instead of when resources are collected.