### PR TITLE
Add cost and cost_int placeholders for mability

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/PlaceholderApiProvider.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/hooks/PlaceholderApiProvider.java
@@ -174,7 +174,9 @@ public class PlaceholderApiProvider extends PlaceholderExpansion {
                             .replace("_active", "")
                             .replace("_value_int", "")
                             .replace("_value", "")
-                            .replace("_roman", ""));
+                            .replace("_roman", "")
+                            .replace("_cost_int", "")
+                            .replace("_cost", ""));
             ManaAbility manaAbility = plugin.getManaAbilityRegistry().getOrNull(id);
 
             if (manaAbility == null) return null;
@@ -190,6 +192,10 @@ public class PlaceholderApiProvider extends PlaceholderExpansion {
                     return String.valueOf(user.getManaAbilityData(manaAbility).isActivated());
                 } else if (identifier.endsWith("roman")) {
                     return RomanNumber.toRomanAlways(user.getManaAbilityLevel(manaAbility));
+                } else if (identifier.endsWith("cost")) {
+                    return String.valueOf(manaAbility.getManaCost(user.getManaAbilityLevel(manaAbility)));
+                } else if (identifier.endsWith("cost_int")) {
+                    return String.valueOf(Math.round(manaAbility.getManaCost(user.getManaAbilityLevel(manaAbility))));
                 } else if (identifier.endsWith(manaAbility.name().toLowerCase(Locale.ROOT))) {
                     return String.valueOf(user.getManaAbilityLevel(manaAbility));
                 }
@@ -484,6 +490,8 @@ public class PlaceholderApiProvider extends PlaceholderExpansion {
                 "%auraskills_mability_[ability]_active%",
                 "%auraskills_mability_[ability]_value%",
                 "%auraskills_mability_[ability]_value_int%",
+                "%auraskills_mability_[ability]_cost%",
+                "%auraskills_mability_[ability]_cost_int%",
                 "%auraskills_trait_[trait]",
                 "%auraskills_trait_[trait]_bonus",
                 "%auraskills_trait_[trait]_menu",

--- a/wiki/placeholders.md
+++ b/wiki/placeholders.md
@@ -61,6 +61,8 @@ AuraSkills provides PlaceholderAPI placeholders that work out of the box, withou
 * `%auraskills_mability_[ability]_value%` - Gets the mana ability value.
 * `%auraskills_mability_[ability]_value_int%` - Gets mana ability value rounded to an integer
 * `%auraskills_mability_[ability]_active%` - Returns true if mana ability is active, false otherwise.
+* `%auraskills_mability_[ability]_cost%` - Gets mana ability mana cost.
+* `%auraskills_mability_[ability]_cost_int%` - Gets mana ability mana cost rounded to an integer.
 * `%auraskills_trait_[trait]%` - Gets the effective level of a trait.
 * `%auraskills_trait_[trait]_bonus%` - Gets the bonus level of a trait (level excluding the base value).
 * `%auraskills_trait_[trait]_menu%` - Gets the trait in the same format displayed in the stats menu.


### PR DESCRIPTION
This PR adds two simple placeholders `%auraskills_mability_[ability]_cost%` and `%auraskills_mability_[ability]_cost_int%` that return the specified mana ability's mana cost as double and int respectively.