### PR TITLE
Allow item/armor commands to target others

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/ArmorCommand.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/ArmorCommand.java
@@ -1,388 +1,197 @@
 package dev.aurelium.auraskills.bukkit.commands;
 
 import co.aikar.commands.BaseCommand;
-import co.aikar.commands.InvalidCommandArgument;
-import co.aikar.commands.annotation.*;
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Default;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Flags;
+import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.Subcommand;
 import dev.aurelium.auraskills.api.item.ModifierType;
-import dev.aurelium.auraskills.api.registry.NamespacedId;
-import dev.aurelium.auraskills.api.skill.Multiplier;
 import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.api.stat.Stat;
-import dev.aurelium.auraskills.api.stat.StatModifier;
 import dev.aurelium.auraskills.api.trait.Trait;
-import dev.aurelium.auraskills.api.trait.TraitModifier;
 import dev.aurelium.auraskills.api.util.AuraSkillsModifier.Operation;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
-import dev.aurelium.auraskills.bukkit.item.SkillsItem;
-import dev.aurelium.auraskills.bukkit.item.SkillsItem.MetaType;
-import dev.aurelium.auraskills.bukkit.stat.StatFormat;
-import dev.aurelium.auraskills.common.message.type.CommandMessage;
-import dev.aurelium.auraskills.common.util.text.TextUtil;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-
-import java.util.Locale;
-import java.util.Map;
 
 @CommandAlias("%skills_alias")
 @Subcommand("armor")
 public class ArmorCommand extends BaseCommand {
 
-    private final AuraSkills plugin;
-    private final StatFormat format;
+    private final BaseItemCommand baseItemCommand;
 
     public ArmorCommand(AuraSkills plugin) {
-        this.plugin = plugin;
-        this.format = new StatFormat(plugin);
+        this.baseItemCommand = new BaseItemCommand(plugin, "ARMOR", ModifierType.ARMOR);
     }
 
     @Subcommand("modifier add")
-    @CommandCompletion("@stats @nothing @modifier_operations false|true")
+    @CommandCompletion("@stats @nothing @modifier_operations true|false false|true @players")
     @CommandPermission("auraskills.command.armor.modifier")
     @Description("%desc_armor_modifier_add")
-    public void onArmorModifierAdd(@Flags("itemheld") Player player, Stat stat, double value, @Default("add") Operation operation, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (StatModifier statModifier : skillsItem.getStatModifiers(ModifierType.ARMOR)) {
-            if (statModifier.stat() == stat) {
-                player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_ADD_ALREADY_EXISTS, locale), stat, locale));
-                return;
-            }
-        }
-        if (lore) {
-            skillsItem.addModifierLore(ModifierType.ARMOR, stat, value, operation, locale);
-        }
-        skillsItem.addModifier(MetaType.MODIFIER, ModifierType.ARMOR, stat, value, operation);
-        ItemStack newItem = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(newItem);
-        player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_ADD_ADDED, locale), stat, value, operation, locale));
+    public void onItemModifierAdd(CommandIssuer issuer, Stat stat, double value, @Default("add") Operation operation, @Default("true") boolean lore,
+            @Default("false") boolean overwrite, @Flags("other") @CommandPermission("auraskills.command.armor.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierAdd(issuer, player, stat, value, operation, lore, overwrite)
+        );
     }
 
     @Subcommand("modifier remove")
-    @CommandCompletion("@stats false|true")
+    @CommandCompletion("@stats true|false @players")
     @CommandPermission("auraskills.command.armor.modifier")
     @Description("%desc_armor_modifier_remove")
-    public void onArmorModifierRemove(@Flags("itemheld") Player player, Stat stat, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        boolean removed = false;
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (StatModifier modifier : skillsItem.getStatModifiers(ModifierType.ARMOR)) {
-            if (modifier.stat() == stat) {
-                skillsItem.removeModifier(MetaType.MODIFIER, ModifierType.ARMOR, stat);
-                removed = true;
-                break;
-            }
-        }
-        if (lore) {
-            skillsItem.removeModifierLore(stat, locale);
-        }
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        if (removed) {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_REMOVE_REMOVED, locale), stat, locale));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_REMOVE_DOES_NOT_EXIST, locale), stat, locale));
-        }
+    public void onItemModifierRemove(CommandIssuer issuer, Stat stat, @Default("true") boolean lore,
+            @Flags("other") @CommandPermission("auraskills.command.armor.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierRemove(issuer, player, stat, lore)
+        );
     }
 
     @Subcommand("modifier list")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.armor.modifier")
     @Description("%desc_armor_modifier_list")
-    public void onArmorModifierList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        StringBuilder message = new StringBuilder(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (StatModifier modifier : skillsItem.getStatModifiers(ModifierType.ARMOR)) {
-            message.append("\n").append(format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_LIST_ENTRY, locale), modifier, locale));
-        }
-        player.sendMessage(message.toString());
+    public void onItemModifierList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierList(issuer, player)
+        );
     }
 
     @Subcommand("modifier removeall")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.armor.modifier")
     @Description("%desc_armor_modifier_removeall")
-    public void onArmorModifierRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        SkillsItem skillsItem = new SkillsItem(player.getInventory().getItemInMainHand(), plugin);
-        skillsItem.removeAll(SkillsItem.MetaType.MODIFIER, ModifierType.ARMOR);
-        ItemStack item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ARMOR_MODIFIER_REMOVEALL_REMOVED, locale));
+    public void onItemModifierRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierRemoveAll(issuer, player)
+        );
     }
 
     @Subcommand("trait add")
-    @CommandCompletion("@traits @nothing @modifier_operations false|true")
-    @CommandPermission("auraskills.command.armor.modifier")
+    @CommandCompletion("@traits @nothing @modifier_operations true|false false|true @players")
+    @CommandPermission("auraskills.command.armor.trait")
     @Description("%desc_armor_trait_add")
-    public void onItemTraitAdd(@Flags("itemheld") Player player, Trait trait, double value, @Default("add") Operation operation, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-
-        for (TraitModifier modifier : skillsItem.getTraitModifiers(ModifierType.ARMOR)) {
-            if (modifier.trait().equals(trait)) {
-                player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_TRAIT_ADD_ALREADY_EXISTS, locale), trait, locale));
-                return;
-            }
-        }
-        if (lore) {
-            skillsItem.addModifierLore(ModifierType.ARMOR, trait, value, operation, locale);
-        }
-        skillsItem.addModifier(MetaType.TRAIT_MODIFIER, ModifierType.ARMOR, trait, value, operation);
-        ItemStack newItem = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(newItem);
-        player.sendMessage(plugin.getPrefix(locale) +
-                format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_TRAIT_ADD_ADDED, locale), trait, value, operation, locale));
+    public void onItemTraitAdd(CommandIssuer issuer, Trait trait, double value, @Default("add") Operation operation, @Default("true") boolean lore,
+            @Default("false") boolean overwrite, @Flags("other") @CommandPermission("auraskills.command.armor.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitAdd(issuer, player, trait, value, operation, lore, overwrite)
+        );
     }
 
     @Subcommand("trait remove")
-    @CommandCompletion("@traits")
-    @CommandPermission("auraskills.command.armor.modifier")
+    @CommandCompletion("@traits true|false @players")
+    @CommandPermission("auraskills.command.armor.trait")
     @Description("%desc_armor_trait_remove")
-    public void onItemTraitRemove(@Flags("itemheld") Player player, Trait trait) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        boolean removed = false;
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (TraitModifier modifier : skillsItem.getTraitModifiers(ModifierType.ARMOR)) {
-            if (modifier.trait().equals(trait)) {
-                skillsItem.removeModifier(MetaType.TRAIT_MODIFIER, ModifierType.ARMOR, trait);
-                removed = true;
-                break;
-            }
-        }
-        // Lore removal not implemented yet
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        if (removed) {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_REMOVE_REMOVED, locale), trait, locale));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_REMOVE_DOES_NOT_EXIST, locale), trait, locale));
-        }
+    public void onItemTraitRemove(CommandIssuer issuer, Trait trait, @Default("true") boolean lore, @Flags("other") @CommandPermission("auraskills.command.armor.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitRemove(issuer, player, trait, lore)
+        );
     }
 
     @Subcommand("trait list")
-    @CommandPermission("auraskills.command.armor.modifier")
+    @CommandCompletion("@players")
+    @CommandPermission("auraskills.command.armor.trait")
     @Description("%desc_armor_trait_list")
-    public void onItemTraitList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        StringBuilder message = new StringBuilder(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (TraitModifier modifier : skillsItem.getTraitModifiers(ModifierType.ARMOR)) {
-            message.append("\n").append(format.applyPlaceholders(plugin.getMsg(CommandMessage.ARMOR_MODIFIER_LIST_ENTRY, locale), modifier, locale));
-        }
-        player.sendMessage(message.toString());
+    public void onItemTraitList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitList(issuer, player)
+        );
     }
 
     @Subcommand("trait removeall")
-    @CommandPermission("auraskills.command.armor.modifier")
+    @CommandCompletion("@players")
+    @CommandPermission("auraskills.command.armor.trait")
     @Description("%desc_armor_trait_removeall")
-    public void onItemTraitRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-
-        skillsItem.removeAll(MetaType.TRAIT_MODIFIER, ModifierType.ARMOR);
-        item = skillsItem.getItem();
-
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ARMOR_MODIFIER_REMOVEALL_REMOVED, locale));
+    public void onItemTraitRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitRemoveAll(issuer, player)
+        );
     }
 
     @Subcommand("requirement add")
+    @CommandCompletion("@skills @nothing true|false false|true @players")
     @CommandPermission("auraskills.command.armor.requirement")
-    @CommandCompletion("@skills @nothing false|true")
     @Description("%desc_armor_requirement_add")
-    public void onArmorRequirementAdd(@Flags("itemheld") Player player, Skill skill, int level, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        if (skillsItem.getRequirements(ModifierType.ARMOR).containsKey(skill)) {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_ADD_ALREADY_EXISTS, locale),
-                    "{skill}", skill.getDisplayName(locale)));
-            return;
-        }
-        skillsItem.addRequirement(ModifierType.ARMOR, skill, level);
-        if (lore) {
-            skillsItem.addRequirementLore(ModifierType.ARMOR, skill, level, locale);
-        }
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_ADD_ADDED, locale),
-                "{skill}", skill.getDisplayName(locale),
-                "{level}", String.valueOf(level)));
+    public void onItemRequirementAdd(CommandIssuer issuer, Skill skill, int level, @Default("true") boolean lore,
+            @Default("false") boolean overwrite, @Flags("other") @CommandPermission("auraskills.command.armor.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementAdd(issuer, player, skill, level, lore, overwrite)
+        );
     }
 
     @Subcommand("requirement remove")
+    @CommandCompletion("@skills true|false @players")
     @CommandPermission("auraskills.command.armor.requirement")
-    @CommandCompletion("@skills false|true")
     @Description("%desc_armor_requirement_remove")
-    public void onArmorRequirementRemove(@Flags("itemheld") Player player, Skill skill, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        if (skillsItem.getRequirements(ModifierType.ARMOR).containsKey(skill)) {
-            skillsItem.removeRequirement(ModifierType.ARMOR, skill);
-            if (lore) {
-                skillsItem.removeRequirementLore(skill);
-            }
-            item = skillsItem.getItem();
-            player.getInventory().setItemInMainHand(item);
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_REMOVE_REMOVED, locale),
-                    "{skill}", skill.getDisplayName(locale)));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_REMOVE_DOES_NOT_EXIST, locale),
-                    "{skill}", skill.getDisplayName(locale)));
-        }
+    public void onItemRequirementRemove(CommandIssuer issuer, Skill skill, @Default("true") boolean lore,
+            @Flags("other") @CommandPermission("auraskills.command.armor.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementRemove(issuer, player, skill, lore)
+        );
     }
 
     @Subcommand("requirement list")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.armor.requirement")
     @Description("%desc_armor_requirement_list")
-    public void onArmorRequirementList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        player.sendMessage(plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(player.getInventory().getItemInMainHand(), plugin);
-        for (Map.Entry<Skill, Integer> entry : skillsItem.getRequirements(ModifierType.ARMOR).entrySet()) {
-            player.sendMessage(TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_LIST_ENTRY, locale),
-                    "{skill}", entry.getKey().getDisplayName(locale),
-                    "{level}", String.valueOf(entry.getValue())));
-        }
+    public void onItemRequirementList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementList(issuer, player)
+        );
     }
 
     @Subcommand("requirement removeall")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.armor.requirement")
     @Description("%desc_armor_requirement_removeall")
-    public void onArmorRequirementRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        SkillsItem skillsItem = new SkillsItem(player.getInventory().getItemInMainHand(), plugin);
-        skillsItem.removeAll(SkillsItem.MetaType.REQUIREMENT, ModifierType.ARMOR);
-        ItemStack item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ARMOR_REQUIREMENT_REMOVEALL_REMOVED, locale));
+    public void onItemRequirementRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementRemoveAll(issuer, player)
+        );
     }
 
     @Subcommand("multiplier add")
-    @CommandCompletion("@skills_global @nothing true|false")
+    @CommandCompletion("@skills_global @nothing true|false false|true @players")
     @CommandPermission("auraskills.command.armor.multiplier")
     @Description("%desc_armor_multiplier_add")
-    public void onArmorMultiplierAdd(@Flags("itemheld") Player player, String target, double value, @Default("true") boolean lore) {
-        ItemStack item = player.getInventory().getItemInMainHand();
-        Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
-        Locale locale = plugin.getUser(player).getLocale();
-
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        if (skill != null) { // Add multiplier for specific skill
-            for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ARMOR)) {
-                if (multiplier.skill() == skill) {
-                    player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_ADD_ALREADY_EXISTS, locale),
-                            "{target}", skill.getDisplayName(locale)));
-                    return;
-                }
-            }
-            if (lore) {
-                skillsItem.addMultiplierLore(ModifierType.ARMOR, skill, value, locale);
-            }
-            skillsItem.addMultiplier(ModifierType.ARMOR, skill, value);
-            ItemStack newItem = skillsItem.getItem();
-            player.getInventory().setItemInMainHand(newItem);
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_ADD_ADDED, locale),
-                    "{target}", skill.getDisplayName(locale), "{value}", String.valueOf(value)));
-        } else if (target.equalsIgnoreCase("global")) { // Add multiplier for all skills
-            String global = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
-            for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ARMOR)) {
-                if (multiplier.skill() == null) {
-                    player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_ADD_ALREADY_EXISTS, locale),
-                            "{target}", global));
-                    return;
-                }
-            }
-            if (lore) {
-                skillsItem.addMultiplierLore(ModifierType.ARMOR, null, value, locale);
-            }
-            skillsItem.addMultiplier(ModifierType.ARMOR, null, value);
-            ItemStack newItem = skillsItem.getItem();
-            player.getInventory().setItemInMainHand(newItem);
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_ADD_ADDED, locale),
-                    "{target}", global, "{value}", String.valueOf(value)));
-        } else {
-            throw new InvalidCommandArgument("Target must be valid skill name or global");
-        }
+    public void onItemMultiplierAdd(CommandIssuer issuer, String target, double value, @Default("true") boolean lore, @Default("false") boolean overwrite,
+            @Flags("other") @CommandPermission("auraskills.command.armor.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierAdd(issuer, player, target, value, lore, overwrite)
+        );
     }
 
     @Subcommand("multiplier remove")
-    @CommandCompletion("@skills_global")
+    @CommandCompletion("@skills_global true|false @players")
     @CommandPermission("auraskills.command.armor.multiplier")
     @Description("%desc_armor_multiplier_remove")
-    public void onArmorMultiplierRemove(@Flags("itemheld") Player player, String target) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
-        boolean removed = false;
-
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ARMOR)) {
-            if (multiplier.skill() == skill) {
-                skillsItem.removeMultiplier(ModifierType.ARMOR, skill);
-                removed = true;
-                break;
-            }
-        }
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        // Use skill display name if skill is not null, otherwise use global name
-        String targetName;
-        if (skill != null) {
-            targetName = skill.getDisplayName(locale);
-        } else if (target.equalsIgnoreCase("global")) {
-            targetName = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
-        } else {
-            throw new InvalidCommandArgument("Target must be valid skill name or global");
-        }
-        if (removed) {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_REMOVE_REMOVED, locale),
-                    "{target}", targetName));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_REMOVE_DOES_NOT_EXIST, locale),
-                    "{target}", targetName));
-        }
+    public void onItemMultiplierRemove(CommandIssuer issuer, String target, @Default("true") boolean lore, @Flags("other") @CommandPermission("auraskills.command.armor.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierRemove(issuer, player, target, lore)
+        );
     }
 
     @Subcommand("multiplier list")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.armor.multiplier")
     @Description("%desc_armor_multiplier_list")
-    public void onArmorMultiplierList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        StringBuilder message = new StringBuilder(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ARMOR)) {
-            String targetName;
-            if (multiplier.skill() != null) {
-                targetName = multiplier.skill().getDisplayName(locale);
-            } else {
-                targetName = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
-            }
-            message.append("\n").append(TextUtil.replace(plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_LIST_ENTRY, locale),
-                    "{target}", targetName, "{value}", String.valueOf(multiplier.value())));
-        }
-        player.sendMessage(message.toString());
+    public void onItemMultiplierList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierList(issuer, player)
+        );
     }
 
     @Subcommand("multiplier removeall")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.armor.multiplier")
     @Description("%desc_armor_multiplier_removeall")
-    public void onArmorMultiplierRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        SkillsItem skillsItem = new SkillsItem(player.getInventory().getItemInMainHand(), plugin);
-        skillsItem.removeAll(SkillsItem.MetaType.MULTIPLIER, ModifierType.ARMOR);
-        player.getInventory().setItemInMainHand(skillsItem.getItem());
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ARMOR_MULTIPLIER_REMOVEALL_REMOVED, locale));
+    public void onItemMultiplierRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.armor.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierRemoveAll(issuer, player)
+        );
     }
 
 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/BaseItemCommand.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/BaseItemCommand.java
@@ -16,10 +16,12 @@ import dev.aurelium.auraskills.bukkit.item.SkillsItem;
 import dev.aurelium.auraskills.bukkit.item.SkillsItem.MetaType;
 import dev.aurelium.auraskills.bukkit.stat.StatFormat;
 import dev.aurelium.auraskills.common.message.type.ACFCoreMessage;
+import dev.aurelium.auraskills.common.message.type.ACFMinecraftMessage;
 import dev.aurelium.auraskills.common.message.type.CommandMessage;
 import dev.aurelium.auraskills.common.util.text.TextUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Map;
@@ -41,7 +43,7 @@ public class BaseItemCommand {
 
     protected void handlePlayerTarget(
                 CommandIssuer issuer,
-                Player other,
+                @Nullable Player other,
                 BiConsumer<Player, Locale> action) {
         Locale locale = plugin.getLocale(issuer);
         if (other == null) {
@@ -51,8 +53,7 @@ public class BaseItemCommand {
             }
 
             Player player = issuer.getIssuer();
-            if (!checkItemHeld(issuer, player, locale)) {
-                issuer.sendMessage(plugin.getMsg(ACFCoreMessage.ERROR_PERFORMING_COMMAND, locale));
+            if (missingHeldItem(issuer, player, locale)) {
                 return;
             }
 
@@ -60,21 +61,20 @@ public class BaseItemCommand {
             return;
         }
 
-        if (!checkItemHeld(issuer, other, locale)) {
-            issuer.sendMessage(plugin.getMsg(ACFCoreMessage.ERROR_PERFORMING_COMMAND, locale));
+        if (missingHeldItem(issuer, other, locale)) {
             return;
         }
 
         action.accept(other, locale);
     }
 
-    private boolean checkItemHeld(CommandIssuer issuer, Player player, Locale locale) {
+    private boolean missingHeldItem(CommandIssuer issuer, Player player, Locale locale) {
         ItemStack item = player.getInventory().getItemInMainHand();
-        if (item == null || item.getType().isAir()) {
-            issuer.sendMessage(plugin.getMsg(ACFCoreMessage.ERROR_PERFORMING_COMMAND, locale));
-            return false;
+        if (item.getType().isAir()) {
+            issuer.sendMessage(plugin.getMsg(ACFMinecraftMessage.YOU_MUST_BE_HOLDING_ITEM, locale));
+            return true;
         }
-        return true;
+        return false;
     }
 
     protected CommandMessage getCommandMessage(String key) {
@@ -319,7 +319,7 @@ public class BaseItemCommand {
                     }
                     skillsItem.removeMultiplier(commandModifierType, skill);
                     if (lore) {
-                        skillsItem.removeMultiplierLore(skill, locale);
+                        skillsItem.removeMultiplierLore(commandModifierType, skill, locale);
                     }
                 }
             }
@@ -342,7 +342,7 @@ public class BaseItemCommand {
                     }
                     skillsItem.removeMultiplier(commandModifierType, null);
                     if (lore) {
-                        skillsItem.removeMultiplierLore(null, locale);
+                        skillsItem.removeMultiplierLore(commandModifierType, null, locale);
                     }
                 }
             }
@@ -359,7 +359,7 @@ public class BaseItemCommand {
         }
     }
 
-    protected void onItemMultiplierRemove(CommandIssuer issuer, Player player, String target, Boolean lore) {
+    protected void onItemMultiplierRemove(CommandIssuer issuer, Player player, String target, boolean lore) {
         Locale locale = plugin.getLocale(issuer);
         ItemStack item = player.getInventory().getItemInMainHand();
         Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
@@ -370,7 +370,7 @@ public class BaseItemCommand {
             if (multiplier.skill() == skill) {
                 skillsItem.removeMultiplier(commandModifierType, skill);
                 if (lore) {
-                    skillsItem.removeMultiplierLore(skill, locale);
+                    skillsItem.removeMultiplierLore(commandModifierType, skill, locale);
                 }
                 removed = true;
                 break;

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/BaseItemCommand.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/BaseItemCommand.java
@@ -1,0 +1,429 @@
+package dev.aurelium.auraskills.bukkit.commands;
+
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.InvalidCommandArgument;
+import dev.aurelium.auraskills.api.item.ModifierType;
+import dev.aurelium.auraskills.api.registry.NamespacedId;
+import dev.aurelium.auraskills.api.skill.Multiplier;
+import dev.aurelium.auraskills.api.skill.Skill;
+import dev.aurelium.auraskills.api.stat.Stat;
+import dev.aurelium.auraskills.api.stat.StatModifier;
+import dev.aurelium.auraskills.api.trait.Trait;
+import dev.aurelium.auraskills.api.trait.TraitModifier;
+import dev.aurelium.auraskills.api.util.AuraSkillsModifier.Operation;
+import dev.aurelium.auraskills.bukkit.AuraSkills;
+import dev.aurelium.auraskills.bukkit.item.SkillsItem;
+import dev.aurelium.auraskills.bukkit.item.SkillsItem.MetaType;
+import dev.aurelium.auraskills.bukkit.stat.StatFormat;
+import dev.aurelium.auraskills.common.message.type.ACFCoreMessage;
+import dev.aurelium.auraskills.common.message.type.CommandMessage;
+import dev.aurelium.auraskills.common.util.text.TextUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class BaseItemCommand {
+
+    protected final AuraSkills plugin;
+    protected final StatFormat format;
+    protected final String prefixCommandMessage;
+    protected final ModifierType commandModifierType;
+
+    public BaseItemCommand(AuraSkills plugin, String prefix, ModifierType type) {
+        this.plugin = plugin;
+        this.format = new StatFormat(plugin);
+        this.prefixCommandMessage = prefix;
+        this.commandModifierType = type;
+    }
+
+    protected void handlePlayerTarget(
+                CommandIssuer issuer,
+                Player other,
+                BiConsumer<Player, Locale> action) {
+        Locale locale = plugin.getLocale(issuer);
+        if (other == null) {
+            if (!issuer.isPlayer()) {
+                issuer.sendMessage(plugin.getMsg(ACFCoreMessage.NOT_ALLOWED_ON_CONSOLE, locale));
+                return;
+            }
+
+            Player player = issuer.getIssuer();
+            if (!checkItemHeld(issuer, player, locale)) {
+                issuer.sendMessage(plugin.getMsg(ACFCoreMessage.ERROR_PERFORMING_COMMAND, locale));
+                return;
+            }
+
+            action.accept(player, locale);
+            return;
+        }
+
+        if (!checkItemHeld(issuer, other, locale)) {
+            issuer.sendMessage(plugin.getMsg(ACFCoreMessage.ERROR_PERFORMING_COMMAND, locale));
+            return;
+        }
+
+        action.accept(other, locale);
+    }
+
+    private boolean checkItemHeld(CommandIssuer issuer, Player player, Locale locale) {
+        ItemStack item = player.getInventory().getItemInMainHand();
+        if (item == null || item.getType().isAir()) {
+            issuer.sendMessage(plugin.getMsg(ACFCoreMessage.ERROR_PERFORMING_COMMAND, locale));
+            return false;
+        }
+        return true;
+    }
+
+    protected CommandMessage getCommandMessage(String key) {
+        return CommandMessage.valueOf(prefixCommandMessage + "_" + key);
+    }
+
+    protected void onItemModifierAdd(CommandIssuer issuer, Player player, Stat stat, double value, Operation operation, boolean lore, boolean overwrite) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+
+        for (StatModifier statModifier : skillsItem.getStatModifiers(commandModifierType)) {
+            if (statModifier.stat().equals(stat)) {
+                if (!overwrite) {
+                    issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_ADD_ALREADY_EXISTS"), locale), stat, locale));
+                    return;
+                }
+                skillsItem.removeModifier(MetaType.MODIFIER, commandModifierType, stat);
+                if (lore) {
+                    skillsItem.removeModifierLore(stat, locale);
+                }
+            }
+        }
+        if (lore) {
+            skillsItem.addModifierLore(commandModifierType, stat, value, operation, locale);
+        }
+        skillsItem.addModifier(MetaType.MODIFIER, commandModifierType, stat, value, operation);
+        ItemStack newItem = skillsItem.getItem();
+        player.getInventory().setItemInMainHand(newItem);
+        issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_ADD_ADDED"), locale), stat, value, operation, locale));
+    }
+
+    protected void onItemModifierRemove(CommandIssuer issuer, Player player, Stat stat, boolean lore) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        boolean removed = false;
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (StatModifier modifier : skillsItem.getStatModifiers(commandModifierType)) {
+            if (modifier.stat() == stat) {
+                skillsItem.removeModifier(MetaType.MODIFIER, commandModifierType, stat);
+                removed = true;
+                break;
+            }
+        }
+        if (lore) {
+            skillsItem.removeModifierLore(stat, locale);
+        }
+        item = skillsItem.getItem();
+        player.getInventory().setItemInMainHand(item);
+        if (removed) {
+            issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_REMOVE_REMOVED"), locale), stat, locale));
+        } else {
+            issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_REMOVE_DOES_NOT_EXIST"), locale), stat, locale));
+        }
+    }
+
+    protected void onItemModifierList(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        StringBuilder message = new StringBuilder(plugin.getMsg(getCommandMessage("MODIFIER_LIST_HEADER"), locale));
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (StatModifier modifier : skillsItem.getStatModifiers(commandModifierType)) {
+            message.append("\n").append(format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_LIST_ENTRY"), locale), modifier, locale));
+        }
+        issuer.sendMessage(message.toString());
+    }
+
+    protected void onItemModifierRemoveAll(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+
+        skillsItem.removeAll(MetaType.MODIFIER, commandModifierType);
+        item = skillsItem.getItem();
+
+        player.getInventory().setItemInMainHand(item);
+        issuer.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(getCommandMessage("MODIFIER_REMOVEALL_REMOVED"), locale));
+    }
+
+    protected void onItemTraitAdd(CommandIssuer issuer, Player player, Trait trait, double value, Operation operation, boolean lore, boolean overwrite) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+
+        for (TraitModifier modifier : skillsItem.getTraitModifiers(commandModifierType)) {
+            if (modifier.trait().equals(trait)) {
+                if (!overwrite) {
+                    issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("TRAIT_ADD_ALREADY_EXISTS"), locale), trait, locale));
+                    return;
+                }
+                skillsItem.removeModifier(MetaType.TRAIT_MODIFIER, commandModifierType, trait);
+                if (lore) {
+                    skillsItem.removeModifierLore(trait, locale);
+                }
+            }
+        }
+        if (lore) {
+            skillsItem.addModifierLore(commandModifierType, trait, value, operation, locale);
+        }
+        skillsItem.addModifier(MetaType.TRAIT_MODIFIER, commandModifierType, trait, value, operation);
+        ItemStack newItem = skillsItem.getItem();
+        player.getInventory().setItemInMainHand(newItem);
+        issuer.sendMessage(plugin.getPrefix(locale) +
+                format.applyPlaceholders(plugin.getMsg(getCommandMessage("TRAIT_ADD_ADDED"), locale), trait, value, operation, locale));
+    }
+
+    protected void onItemTraitRemove(CommandIssuer issuer, Player player, Trait trait, boolean lore) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        boolean removed = false;
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (TraitModifier modifier : skillsItem.getTraitModifiers(commandModifierType)) {
+            if (modifier.trait().equals(trait)) {
+                skillsItem.removeModifier(MetaType.TRAIT_MODIFIER, commandModifierType, trait);
+                removed = true;
+                break;
+            }
+        }
+        if (lore) {
+            skillsItem.removeModifierLore(trait, locale);
+        }
+        item = skillsItem.getItem();
+        player.getInventory().setItemInMainHand(item);
+        if (removed) {
+            issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_REMOVE_REMOVED"), locale), trait, locale));
+        } else {
+            issuer.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_REMOVE_DOES_NOT_EXIST"), locale), trait, locale));
+        }
+    }
+
+    protected void onItemTraitList(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        StringBuilder message = new StringBuilder(plugin.getMsg(getCommandMessage("MODIFIER_LIST_HEADER"), locale));
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (TraitModifier modifier : skillsItem.getTraitModifiers(commandModifierType)) {
+            message.append("\n").append(format.applyPlaceholders(plugin.getMsg(getCommandMessage("MODIFIER_LIST_ENTRY"), locale), modifier, locale));
+        }
+        issuer.sendMessage(message.toString());
+    }
+
+    protected void onItemTraitRemoveAll(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+
+        skillsItem.removeAll(MetaType.TRAIT_MODIFIER, commandModifierType);
+        item = skillsItem.getItem();
+
+        player.getInventory().setItemInMainHand(item);
+        issuer.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(getCommandMessage("MODIFIER_REMOVEALL_REMOVED"), locale));
+    }
+
+    protected void onItemRequirementAdd(CommandIssuer issuer, Player player, Skill skill, int level, boolean lore, boolean overwrite) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        if (skillsItem.getRequirements(commandModifierType).containsKey(skill)) {
+            if (!overwrite) {
+                issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("REQUIREMENT_ADD_ALREADY_EXISTS"), locale), "{skill}", skill.getDisplayName(locale)));
+                return;
+            }
+            skillsItem.removeRequirement(commandModifierType, skill);
+            if (lore) {
+                skillsItem.removeRequirementLore(skill, locale);
+            }
+        }
+        skillsItem.addRequirement(commandModifierType, skill, level);
+        if (lore) {
+            skillsItem.addRequirementLore(commandModifierType, skill, level, locale);
+        }
+        item = skillsItem.getItem();
+
+        player.getInventory().setItemInMainHand(item);
+        issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("REQUIREMENT_ADD_ADDED"), locale),
+                "{skill}", skill.getDisplayName(locale),
+                "{level}", String.valueOf(level)));
+    }
+
+    protected void onItemRequirementRemove(CommandIssuer issuer, Player player, Skill skill, boolean lore) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        if (skillsItem.getRequirements(commandModifierType).containsKey(skill)) {
+            skillsItem.removeRequirement(commandModifierType, skill);
+            if (lore) {
+                skillsItem.removeRequirementLore(skill, locale);
+            }
+            item = skillsItem.getItem();
+
+            player.getInventory().setItemInMainHand(item);
+            issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("REQUIREMENT_REMOVE_REMOVED"), locale),
+                    "{skill}", skill.getDisplayName(locale)));
+        } else {
+            issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("REQUIREMENT_REMOVE_DOES_NOT_EXIST"), locale),
+                    "{skill}", skill.getDisplayName(locale)));
+        }
+    }
+
+    protected void onItemRequirementList(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+        issuer.sendMessage(plugin.getMsg(getCommandMessage("REQUIREMENT_LIST_HEADER"), locale));
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (Map.Entry<Skill, Integer> entry : skillsItem.getRequirements(commandModifierType).entrySet()) {
+            issuer.sendMessage(TextUtil.replace(plugin.getMsg(getCommandMessage("REQUIREMENT_LIST_ENTRY"), locale),
+                    "{skill}", entry.getKey().getDisplayName(locale),
+                    "{level}", String.valueOf(entry.getValue())));
+        }
+    }
+
+    protected void onItemRequirementRemoveAll(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        skillsItem.removeAll(SkillsItem.MetaType.REQUIREMENT, commandModifierType);
+        item = skillsItem.getItem();
+
+        player.getInventory().setItemInMainHand(item);
+        issuer.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(getCommandMessage("REQUIREMENT_REMOVEALL_REMOVED"), locale));
+    }
+
+    protected void onItemMultiplierAdd(CommandIssuer issuer, Player player, String target, double value, boolean lore, boolean overwrite) {
+        ItemStack item = player.getInventory().getItemInMainHand();
+        Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
+        Locale locale = plugin.getLocale(issuer);
+
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        if (skill != null) { // Add multiplier for specific skill
+            for (Multiplier multiplier : skillsItem.getMultipliers(commandModifierType)) {
+                if (multiplier.skill().equals(skill)) {
+                    if (!overwrite) {
+                        issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_ADD_ALREADY_EXISTS"), locale),
+                                "{target}", skill.getDisplayName(locale)));
+                        return;
+                    }
+                    skillsItem.removeMultiplier(commandModifierType, skill);
+                    if (lore) {
+                        skillsItem.removeMultiplierLore(skill, locale);
+                    }
+                }
+            }
+            if (lore) {
+                skillsItem.addMultiplierLore(commandModifierType, skill, value, locale);
+            }
+            skillsItem.addMultiplier(commandModifierType, skill, value);
+            ItemStack newItem = skillsItem.getItem();
+            player.getInventory().setItemInMainHand(newItem);
+            issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_ADD_ADDED"), locale),
+                    "{target}", skill.getDisplayName(locale), "{value}", String.valueOf(value)));
+        } else if (target.equalsIgnoreCase("global")) { // Add multiplier for all skills
+            String global = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
+            for (Multiplier multiplier : skillsItem.getMultipliers(commandModifierType)) {
+                if (multiplier.skill() == null) {
+                    if (!overwrite) {
+                        issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_ADD_ALREADY_EXISTS"), locale),
+                                "{target}", global));
+                        return;
+                    }
+                    skillsItem.removeMultiplier(commandModifierType, null);
+                    if (lore) {
+                        skillsItem.removeMultiplierLore(null, locale);
+                    }
+                }
+            }
+            if (lore) {
+                skillsItem.addMultiplierLore(commandModifierType, null, value, locale);
+            }
+            skillsItem.addMultiplier(commandModifierType, null, value);
+            ItemStack newItem = skillsItem.getItem();
+            player.getInventory().setItemInMainHand(newItem);
+            issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_ADD_ADDED"), locale),
+                    "{target}", global, "{value}", String.valueOf(value)));
+        } else {
+            throw new InvalidCommandArgument("Target must be valid skill name or global");
+        }
+    }
+
+    protected void onItemMultiplierRemove(CommandIssuer issuer, Player player, String target, Boolean lore) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
+        boolean removed = false;
+
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (Multiplier multiplier : skillsItem.getMultipliers(commandModifierType)) {
+            if (multiplier.skill() == skill) {
+                skillsItem.removeMultiplier(commandModifierType, skill);
+                if (lore) {
+                    skillsItem.removeMultiplierLore(skill, locale);
+                }
+                removed = true;
+                break;
+            }
+        }
+        item = skillsItem.getItem();
+        player.getInventory().setItemInMainHand(item);
+        // Use skill display name if skill is not null, otherwise use global name
+        String targetName;
+        if (skill != null) {
+            targetName = skill.getDisplayName(locale);
+        } else if (target.equalsIgnoreCase("global")) {
+            targetName = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
+        } else {
+            throw new InvalidCommandArgument("Target must be valid skill name or global");
+        }
+        if (removed) {
+            issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_REMOVE_REMOVED"), locale),
+                    "{target}", targetName));
+        } else {
+            issuer.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_REMOVE_DOES_NOT_EXIST"), locale),
+                    "{target}", targetName));
+        }
+    }
+
+    protected void onItemMultiplierList(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+        ItemStack item = player.getInventory().getItemInMainHand();
+        StringBuilder message = new StringBuilder(plugin.getMsg(getCommandMessage("MULTIPLIER_LIST_HEADER"), locale));
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        for (Multiplier multiplier : skillsItem.getMultipliers(commandModifierType)) {
+            String targetName;
+            if (multiplier.skill() != null) {
+                targetName = multiplier.skill().getDisplayName(locale);
+            } else {
+                targetName = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
+            }
+            message.append("\n").append(TextUtil.replace(plugin.getMsg(getCommandMessage("MULTIPLIER_LIST_ENTRY"), locale),
+                    "{target}", targetName, "{value}", String.valueOf(multiplier.value())));
+        }
+        issuer.sendMessage(message.toString());
+    }
+
+    protected void onItemMultiplierRemoveAll(CommandIssuer issuer, Player player) {
+        Locale locale = plugin.getLocale(issuer);
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        SkillsItem skillsItem = new SkillsItem(item, plugin);
+        skillsItem.removeAll(SkillsItem.MetaType.MULTIPLIER, commandModifierType);
+        item = skillsItem.getItem();
+
+        player.getInventory().setItemInMainHand(item);
+        issuer.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(getCommandMessage("MULTIPLIER_REMOVEALL_REMOVED"), locale));
+    }
+
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/ItemCommand.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/ItemCommand.java
@@ -245,24 +245,28 @@ public class ItemCommand extends BaseCommand {
     @CommandCompletion("@players @item_keys")
     @Description("%desc_item_give")
     public void onItemGive(CommandSender sender, @Flags("other") Player player, String key, @Default("-1") int amount) {
-        ItemStack item = plugin.getItemRegistry().getItem(NamespacedId.fromDefault(key)).clone();
+        ItemStack item = plugin.getItemRegistry().getItem(NamespacedId.fromDefault(key));
         Locale locale = plugin.getLocale(sender);
         if (item != null) {
+            // Avoid the registry item from changing.
+            ItemStack clonedItem = item.clone();
+
             if (amount != -1) {
-                item.setAmount(amount);
+                clonedItem.setAmount(amount);
             }
+
             plugin.getScheduler().executeAtEntity(player, (task) -> {
-                ItemStack leftoverItem = ItemUtils.addItemToInventory(player, item);
+                ItemStack leftoverItem = ItemUtils.addItemToInventory(player, clonedItem);
 
                 String senderMsg = TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_GIVE_SENDER, locale),
-                        "{amount}", String.valueOf(item.getAmount()), "{key}", key, "{player}", player.getName());
+                        "{amount}", String.valueOf(clonedItem.getAmount()), "{key}", key, "{player}", player.getName());
                 if (!senderMsg.isEmpty()) {
                     sender.sendMessage(plugin.getPrefix(locale) + senderMsg);
                 }
 
                 if (!sender.equals(player)) {
                     String message = TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_GIVE_RECEIVER, locale),
-                            "{amount}", String.valueOf(item.getAmount()), "{key}", key);
+                            "{amount}", String.valueOf(clonedItem.getAmount()), "{key}", key);
                     if (!message.isEmpty()) {
                         player.sendMessage(plugin.getPrefix(locale) + message);
                     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/ItemCommand.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/commands/ItemCommand.java
@@ -1,21 +1,23 @@
 package dev.aurelium.auraskills.bukkit.commands;
 
 import co.aikar.commands.BaseCommand;
-import co.aikar.commands.InvalidCommandArgument;
-import co.aikar.commands.annotation.*;
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Default;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Flags;
+import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.Subcommand;
 import dev.aurelium.auraskills.api.item.ModifierType;
 import dev.aurelium.auraskills.api.registry.NamespacedId;
-import dev.aurelium.auraskills.api.skill.Multiplier;
 import dev.aurelium.auraskills.api.skill.Skill;
 import dev.aurelium.auraskills.api.stat.Stat;
-import dev.aurelium.auraskills.api.stat.StatModifier;
 import dev.aurelium.auraskills.api.trait.Trait;
-import dev.aurelium.auraskills.api.trait.TraitModifier;
 import dev.aurelium.auraskills.api.util.AuraSkillsModifier.Operation;
 import dev.aurelium.auraskills.bukkit.AuraSkills;
 import dev.aurelium.auraskills.bukkit.item.SkillsItem;
-import dev.aurelium.auraskills.bukkit.item.SkillsItem.MetaType;
-import dev.aurelium.auraskills.bukkit.stat.StatFormat;
 import dev.aurelium.auraskills.bukkit.util.ItemUtils;
 import dev.aurelium.auraskills.common.message.type.CommandMessage;
 import dev.aurelium.auraskills.common.message.type.LevelerMessage;
@@ -27,262 +29,183 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Locale;
-import java.util.Map;
 
 @CommandAlias("%skills_alias")
 @Subcommand("item")
 public class ItemCommand extends BaseCommand {
 
     private final AuraSkills plugin;
-    private final StatFormat format;
+    private final BaseItemCommand baseItemCommand;
 
     public ItemCommand(AuraSkills plugin) {
         this.plugin = plugin;
-        this.format = new StatFormat(plugin);
+        this.baseItemCommand = new BaseItemCommand(plugin, "ITEM", ModifierType.ITEM);
     }
 
     @Subcommand("modifier add")
-    @CommandCompletion("@stats @nothing @modifier_operations false|true")
+    @CommandCompletion("@stats @nothing @modifier_operations true|false false|true @players")
     @CommandPermission("auraskills.command.item.modifier")
     @Description("%desc_item_modifier_add")
-    public void onItemModifierAdd(@Flags("itemheld") Player player, Stat stat, double value, @Default("add") Operation operation, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-
-        for (StatModifier statModifier : skillsItem.getStatModifiers(ModifierType.ITEM)) {
-            if (statModifier.stat() == stat) {
-                player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_ADD_ALREADY_EXISTS, locale), stat, locale));
-                return;
-            }
-        }
-        if (lore) {
-            skillsItem.addModifierLore(ModifierType.ITEM, stat, value, operation, locale);
-        }
-        skillsItem.addModifier(MetaType.MODIFIER, ModifierType.ITEM, stat, value, operation);
-        ItemStack newItem = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(newItem);
-        player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_ADD_ADDED, locale), stat, value, operation, locale));
+    public void onItemModifierAdd(CommandIssuer issuer, Stat stat, double value, @Default("add") Operation operation, @Default("true") boolean lore,
+            @Default("false") boolean overwrite, @Flags("other") @CommandPermission("auraskills.command.item.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierAdd(issuer, player, stat, value, operation, lore, overwrite)
+        );
     }
 
     @Subcommand("modifier remove")
-    @CommandCompletion("@stats false|true")
+    @CommandCompletion("@stats true|false @players")
     @CommandPermission("auraskills.command.item.modifier")
     @Description("%desc_item_modifier_remove")
-    public void onItemModifierRemove(@Flags("itemheld") Player player, Stat stat, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        boolean removed = false;
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (StatModifier modifier : skillsItem.getStatModifiers(ModifierType.ITEM)) {
-            if (modifier.stat() == stat) {
-                skillsItem.removeModifier(MetaType.MODIFIER, ModifierType.ITEM, stat);
-                removed = true;
-                break;
-            }
-        }
-        if (lore) {
-            skillsItem.removeModifierLore(stat, locale);
-        }
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        if (removed) {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_REMOVE_REMOVED, locale), stat, locale));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_REMOVE_DOES_NOT_EXIST, locale), stat, locale));
-        }
+    public void onItemModifierRemove(CommandIssuer issuer, Stat stat, @Default("true") boolean lore,
+            @Flags("other") @CommandPermission("auraskills.command.item.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierRemove(issuer, player, stat, lore)
+        );
     }
 
     @Subcommand("modifier list")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.item.modifier")
     @Description("%desc_item_modifier_list")
-    public void onItemModifierList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        StringBuilder message = new StringBuilder(plugin.getMsg(CommandMessage.ITEM_MODIFIER_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (StatModifier modifier : skillsItem.getStatModifiers(ModifierType.ITEM)) {
-            message.append("\n").append(format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_LIST_ENTRY, locale), modifier, locale));
-        }
-        player.sendMessage(message.toString());
+    public void onItemModifierList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierList(issuer, player)
+        );
     }
 
     @Subcommand("modifier removeall")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.item.modifier")
     @Description("%desc_item_modifier_removeall")
-    public void onItemModifierRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-
-        skillsItem.removeAll(MetaType.MODIFIER, ModifierType.ITEM);
-        item = skillsItem.getItem();
-
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ITEM_MODIFIER_REMOVEALL_REMOVED, locale));
+    public void onItemModifierRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.modifier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemModifierRemoveAll(issuer, player)
+        );
     }
 
     @Subcommand("trait add")
-    @CommandCompletion("@traits @nothing @modifier_operations false|true")
-    @CommandPermission("auraskills.command.item.modifier")
+    @CommandCompletion("@traits @nothing @modifier_operations true|false false|true @players")
+    @CommandPermission("auraskills.command.item.trait")
     @Description("%desc_item_trait_add")
-    public void onItemTraitAdd(@Flags("itemheld") Player player, Trait trait, double value, @Default("add") Operation operation, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-
-        for (TraitModifier modifier : skillsItem.getTraitModifiers(ModifierType.ITEM)) {
-            if (modifier.trait().equals(trait)) {
-                player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_TRAIT_ADD_ALREADY_EXISTS, locale), trait, locale));
-                return;
-            }
-        }
-        if (lore) {
-            skillsItem.addModifierLore(ModifierType.ITEM, trait, value, operation, locale);
-        }
-        skillsItem.addModifier(MetaType.TRAIT_MODIFIER, ModifierType.ITEM, trait, value, operation);
-        ItemStack newItem = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(newItem);
-        player.sendMessage(plugin.getPrefix(locale) +
-                format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_TRAIT_ADD_ADDED, locale), trait, value, operation, locale));
+    public void onItemTraitAdd(CommandIssuer issuer, Trait trait, double value, @Default("add") Operation operation, @Default("true") boolean lore,
+            @Default("false") boolean overwrite, @Flags("other") @CommandPermission("auraskills.command.item.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitAdd(issuer, player, trait, value, operation, lore, overwrite)
+        );
     }
 
     @Subcommand("trait remove")
-    @CommandCompletion("@traits")
-    @CommandPermission("auraskills.command.item.modifier")
+    @CommandCompletion("@traits true|false @players")
+    @CommandPermission("auraskills.command.item.trait")
     @Description("%desc_item_trait_remove")
-    public void onItemTraitRemove(@Flags("itemheld") Player player, Trait trait) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        boolean removed = false;
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (TraitModifier modifier : skillsItem.getTraitModifiers(ModifierType.ITEM)) {
-            if (modifier.trait().equals(trait)) {
-                skillsItem.removeModifier(MetaType.TRAIT_MODIFIER, ModifierType.ITEM, trait);
-                removed = true;
-                break;
-            }
-        }
-        // Lore removal not implemented yet
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        if (removed) {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_REMOVE_REMOVED, locale), trait, locale));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_REMOVE_DOES_NOT_EXIST, locale), trait, locale));
-        }
+    public void onItemTraitRemove(CommandIssuer issuer, Trait trait, @Default("true") boolean lore, @Flags("other") @CommandPermission("auraskills.command.item.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitRemove(issuer, player, trait, lore)
+        );
     }
 
     @Subcommand("trait list")
-    @CommandPermission("auraskills.command.item.modifier")
+    @CommandCompletion("@players")
+    @CommandPermission("auraskills.command.item.trait")
     @Description("%desc_item_trait_list")
-    public void onItemTraitList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        StringBuilder message = new StringBuilder(plugin.getMsg(CommandMessage.ITEM_MODIFIER_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (TraitModifier modifier : skillsItem.getTraitModifiers(ModifierType.ITEM)) {
-            message.append("\n").append(format.applyPlaceholders(plugin.getMsg(CommandMessage.ITEM_MODIFIER_LIST_ENTRY, locale), modifier, locale));
-        }
-        player.sendMessage(message.toString());
+    public void onItemTraitList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitList(issuer, player)
+        );
     }
 
     @Subcommand("trait removeall")
-    @CommandPermission("auraskills.command.item.modifier")
+    @CommandCompletion("@players")
+    @CommandPermission("auraskills.command.item.trait")
     @Description("%desc_item_trait_removeall")
-    public void onItemTraitRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-
-        skillsItem.removeAll(MetaType.TRAIT_MODIFIER, ModifierType.ITEM);
-        item = skillsItem.getItem();
-
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ITEM_MODIFIER_REMOVEALL_REMOVED, locale));
+    public void onItemTraitRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.trait.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemTraitRemoveAll(issuer, player)
+        );
     }
 
     @Subcommand("requirement add")
+    @CommandCompletion("@skills @nothing true|false false|true @players")
     @CommandPermission("auraskills.command.item.requirement")
-    @CommandCompletion("@skills @nothing false|true")
     @Description("%desc_item_requirement_add")
-    public void onItemRequirementAdd(@Flags("itemheld") Player player, Skill skill, int level, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        if (skillsItem.getRequirements(ModifierType.ITEM).containsKey(skill)) {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_ADD_ALREADY_EXISTS, locale), "{skill}", skill.getDisplayName(locale)));
-            return;
-        }
-        skillsItem.addRequirement(ModifierType.ITEM, skill, level);
-        if (lore) {
-            skillsItem.addRequirementLore(ModifierType.ITEM, skill, level, locale);
-        }
-        item = skillsItem.getItem();
-
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_ADD_ADDED, locale),
-                "{skill}", skill.getDisplayName(locale),
-                "{level}", String.valueOf(level)));
+    public void onItemRequirementAdd(CommandIssuer issuer, Skill skill, int level, @Default("true") boolean lore,
+            @Default("false") boolean overwrite, @Flags("other") @CommandPermission("auraskills.command.item.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementAdd(issuer, player, skill, level, lore, overwrite)
+        );
     }
 
     @Subcommand("requirement remove")
+    @CommandCompletion("@skills true|false @players")
     @CommandPermission("auraskills.command.item.requirement")
-    @CommandCompletion("@skills false|true")
     @Description("%desc_item_requirement_remove")
-    public void onItemRequirementRemove(@Flags("itemheld") Player player, Skill skill, @Default("true") boolean lore) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        if (skillsItem.getRequirements(ModifierType.ITEM).containsKey(skill)) {
-            skillsItem.removeRequirement(ModifierType.ITEM, skill);
-            if (lore) {
-                skillsItem.removeRequirementLore(skill);
-            }
-            item = skillsItem.getItem();
-
-            player.getInventory().setItemInMainHand(item);
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_REMOVE_REMOVED, locale),
-                    "{skill}", skill.getDisplayName(locale)));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_REMOVE_DOES_NOT_EXIST, locale),
-                    "{skill}", skill.getDisplayName(locale)));
-        }
+    public void onItemRequirementRemove(CommandIssuer issuer, Skill skill, @Default("true") boolean lore,
+            @Flags("other") @CommandPermission("auraskills.command.item.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementRemove(issuer, player, skill, lore)
+        );
     }
 
     @Subcommand("requirement list")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.item.requirement")
     @Description("%desc_item_requirement_list")
-    public void onItemRequirementList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        player.sendMessage(plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_LIST_HEADER, locale));
-
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (Map.Entry<Skill, Integer> entry : skillsItem.getRequirements(ModifierType.ITEM).entrySet()) {
-            player.sendMessage(TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_LIST_ENTRY, locale),
-                    "{skill}", entry.getKey().getDisplayName(locale),
-                    "{level}", String.valueOf(entry.getValue())));
-        }
+    public void onItemRequirementList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementList(issuer, player)
+        );
     }
 
     @Subcommand("requirement removeall")
+    @CommandCompletion("@players")
     @CommandPermission("auraskills.command.item.requirement")
     @Description("%desc_item_requirement_removeall")
-    public void onItemRequirementRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
+    public void onItemRequirementRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.requirement.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemRequirementRemoveAll(issuer, player)
+        );
+    }
 
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        skillsItem.removeAll(SkillsItem.MetaType.REQUIREMENT, ModifierType.ITEM);
-        item = skillsItem.getItem();
+    @Subcommand("multiplier add")
+    @CommandCompletion("@skills_global @nothing true|false false|true @players")
+    @CommandPermission("auraskills.command.item.multiplier")
+    @Description("%desc_item_multiplier_add")
+    public void onItemMultiplierAdd(CommandIssuer issuer, String target, double value, @Default("true") boolean lore, @Default("false") boolean overwrite,
+            @Flags("other") @CommandPermission("auraskills.command.item.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierAdd(issuer, player, target, value, lore, overwrite)
+        );
+    }
 
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ITEM_REQUIREMENT_REMOVEALL_REMOVED, locale));
+    @Subcommand("multiplier remove")
+    @CommandCompletion("@skills_global true|false @players")
+    @CommandPermission("auraskills.command.item.multiplier")
+    @Description("%desc_item_multiplier_remove")
+    public void onItemMultiplierRemove(CommandIssuer issuer, String target, @Default("true") boolean lore, @Flags("other") @CommandPermission("auraskills.command.item.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierRemove(issuer, player, target, lore)
+        );
+    }
+
+    @Subcommand("multiplier list")
+    @CommandCompletion("@players")
+    @CommandPermission("auraskills.command.item.multiplier")
+    @Description("%desc_item_multiplier_list")
+    public void onItemMultiplierList(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierList(issuer, player)
+        );
+    }
+
+    @Subcommand("multiplier removeall")
+    @CommandCompletion("@players")
+    @CommandPermission("auraskills.command.item.multiplier")
+    @Description("%desc_item_multiplier_removeall")
+    public void onItemMultiplierRemoveAll(CommandIssuer issuer, @Flags("other") @CommandPermission("auraskills.command.item.multiplier.other") @Optional Player other) {
+        baseItemCommand.handlePlayerTarget(issuer, other, (player, locale) ->
+                baseItemCommand.onItemMultiplierRemoveAll(issuer, player)
+        );
     }
 
     @Subcommand("register")
@@ -322,7 +245,7 @@ public class ItemCommand extends BaseCommand {
     @CommandCompletion("@players @item_keys")
     @Description("%desc_item_give")
     public void onItemGive(CommandSender sender, @Flags("other") Player player, String key, @Default("-1") int amount) {
-        ItemStack item = plugin.getItemRegistry().getItem(NamespacedId.fromDefault(key));
+        ItemStack item = plugin.getItemRegistry().getItem(NamespacedId.fromDefault(key)).clone();
         Locale locale = plugin.getLocale(sender);
         if (item != null) {
             if (amount != -1) {
@@ -358,128 +281,6 @@ public class ItemCommand extends BaseCommand {
         } else {
             sender.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_UNREGISTER_NOT_REGISTERED, locale), "{key}", key));
         }
-    }
-
-    @Subcommand("multiplier add")
-    @CommandCompletion("@skills_global @nothing true|false")
-    @CommandPermission("auraskills.command.item.multiplier")
-    @Description("%desc_item_multiplier_add")
-    public void onItemMultiplierAdd(@Flags("itemheld") Player player, String target, double value, @Default("true") boolean lore) {
-        ItemStack item = player.getInventory().getItemInMainHand();
-        Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
-        Locale locale = plugin.getUser(player).getLocale();
-
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        if (skill != null) { // Add multiplier for specific skill
-            for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ITEM)) {
-                if (multiplier.skill() == skill) {
-                    player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_ADD_ALREADY_EXISTS, locale),
-                            "{target}", skill.getDisplayName(locale)));
-                    return;
-                }
-            }
-            if (lore) {
-                skillsItem.addMultiplierLore(ModifierType.ITEM, skill, value, locale);
-            }
-            skillsItem.addMultiplier(ModifierType.ITEM, skill, value);
-            ItemStack newItem = skillsItem.getItem();
-            player.getInventory().setItemInMainHand(newItem);
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_ADD_ADDED, locale),
-                    "{target}", skill.getDisplayName(locale), "{value}", String.valueOf(value)));
-        } else if (target.equalsIgnoreCase("global")) { // Add multiplier for all skills
-            String global = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
-            for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ITEM)) {
-                if (multiplier.skill() == null) {
-                    player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_ADD_ALREADY_EXISTS, locale),
-                            "{target}", global));
-                    return;
-                }
-            }
-            if (lore) {
-                skillsItem.addMultiplierLore(ModifierType.ITEM, null, value, locale);
-            }
-            skillsItem.addMultiplier(ModifierType.ITEM, null, value);
-            ItemStack newItem = skillsItem.getItem();
-            player.getInventory().setItemInMainHand(newItem);
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_ADD_ADDED, locale),
-                    "{target}", global, "{value}", String.valueOf(value)));
-        } else {
-            throw new InvalidCommandArgument("Target must be valid skill name or global");
-        }
-    }
-
-    @Subcommand("multiplier remove")
-    @CommandCompletion("@skills_global")
-    @CommandPermission("auraskills.command.item.multiplier")
-    @Description("%desc_item_multiplier_remove")
-    public void onItemMultiplierRemove(@Flags("itemheld") Player player, String target) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        Skill skill = plugin.getSkillRegistry().getOrNull(NamespacedId.fromDefault(target));
-        boolean removed = false;
-
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ITEM)) {
-            if (multiplier.skill() == skill) {
-                skillsItem.removeMultiplier(ModifierType.ITEM, skill);
-                removed = true;
-                break;
-            }
-        }
-        item = skillsItem.getItem();
-        player.getInventory().setItemInMainHand(item);
-        // Use skill display name if skill is not null, otherwise use global name
-        String targetName;
-        if (skill != null) {
-            targetName = skill.getDisplayName(locale);
-        } else if (target.equalsIgnoreCase("global")) {
-            targetName = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
-        } else {
-            throw new InvalidCommandArgument("Target must be valid skill name or global");
-        }
-        if (removed) {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_REMOVE_REMOVED, locale),
-                    "{target}", targetName));
-        } else {
-            player.sendMessage(plugin.getPrefix(locale) + TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_REMOVE_DOES_NOT_EXIST, locale),
-                    "{target}", targetName));
-        }
-    }
-
-    @Subcommand("multiplier list")
-    @CommandPermission("auraskills.command.item.multiplier")
-    @Description("%desc_item_multiplier_list")
-    public void onItemMultiplierList(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-        ItemStack item = player.getInventory().getItemInMainHand();
-        StringBuilder message = new StringBuilder(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_LIST_HEADER, locale));
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        for (Multiplier multiplier : skillsItem.getMultipliers(ModifierType.ITEM)) {
-            String targetName;
-            if (multiplier.skill() != null) {
-                targetName = multiplier.skill().getDisplayName(locale);
-            } else {
-                targetName = plugin.getMsg(CommandMessage.MULTIPLIER_GLOBAL, locale);
-            }
-            message.append("\n").append(TextUtil.replace(plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_LIST_ENTRY, locale),
-                    "{target}", targetName, "{value}", String.valueOf(multiplier.value())));
-        }
-        player.sendMessage(message.toString());
-    }
-
-    @Subcommand("multiplier removeall")
-    @CommandPermission("auraskills.command.item.multiplier")
-    @Description("%desc_item_multiplier_removeall")
-    public void onItemMultiplierRemoveAll(@Flags("itemheld") Player player) {
-        Locale locale = plugin.getUser(player).getLocale();
-
-        ItemStack item = player.getInventory().getItemInMainHand();
-        SkillsItem skillsItem = new SkillsItem(item, plugin);
-        skillsItem.removeAll(SkillsItem.MetaType.MULTIPLIER, ModifierType.ITEM);
-        item = skillsItem.getItem();
-
-        player.getInventory().setItemInMainHand(item);
-        player.sendMessage(plugin.getPrefix(locale) + plugin.getMsg(CommandMessage.ITEM_MULTIPLIER_REMOVEALL_REMOVED, locale));
     }
 
     @Subcommand("ignore add")

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/SkillsItem.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/SkillsItem.java
@@ -32,7 +32,12 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SkillsItem {
@@ -511,11 +516,23 @@ public class SkillsItem {
         meta.setLore(lore);
     }
 
-    public void removeMultiplierLore(Skill skill, Locale locale) {
+    public void removeMultiplierLore(ModifierType type, @Nullable Skill skill, Locale locale) {
         List<String> lore = meta.getLore();
         if (lore == null || lore.isEmpty()) return;
 
-        lore.removeIf(line -> line.contains(skill.getDisplayName(locale)));
+        if (skill != null) { // Skill multiplier
+            lore.removeIf(line -> line.contains(skill.getDisplayName(locale)));
+        } else { // Global multiplier
+            // We don't have the value so we target both variants.
+            String message = plugin.getMsg(CommandMessage.valueOf(type.name() + "_MULTIPLIER_ADD_GLOBAL_LORE"), locale);
+            String messageSubtract = plugin.getMsg(CommandMessage.valueOf(type.name() + "_MULTIPLIER_ADD_GLOBAL_LORE_SUBTRACT"), locale);
+            // Clear the placeholder so we have a safe value to compare with.
+            String target = message.replace("{value}", "");
+            String targetSubtract = messageSubtract.replace("{value}", "");
+
+            lore.removeIf(line -> line.contains(target) || line.contains(targetSubtract));
+        }
+
         meta.setLore(lore);
     }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/SkillsItem.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/item/SkillsItem.java
@@ -457,9 +457,17 @@ public class SkillsItem {
         meta.setLore(lore);
     }
 
-    public void removeModifierLore(Stat stat, Locale locale) {
+    public void removeModifierLore(NamespaceIdentified identified, Locale locale) {
         List<String> lore = meta.getLore();
-        if (lore != null && !lore.isEmpty()) lore.removeIf(line -> line.contains(stat.getDisplayName(locale)));
+        if (lore == null || lore.isEmpty()) return;
+
+        if (identified instanceof Stat stat) {
+            lore.removeIf(line -> line.contains(stat.getDisplayName(locale)));
+        } else if (identified instanceof Trait trait) {
+            lore.removeIf(line -> line.contains(trait.getDisplayName(locale)));
+        } else if (identified instanceof Skill skill) {
+            lore.removeIf(line -> line.contains(skill.getDisplayName(locale)));
+        }
         meta.setLore(lore);
     }
 
@@ -503,6 +511,14 @@ public class SkillsItem {
         meta.setLore(lore);
     }
 
+    public void removeMultiplierLore(Skill skill, Locale locale) {
+        List<String> lore = meta.getLore();
+        if (lore == null || lore.isEmpty()) return;
+
+        lore.removeIf(line -> line.contains(skill.getDisplayName(locale)));
+        meta.setLore(lore);
+    }
+
     public void addRequirementLore(ModifierType type, Skill skill, int level, Locale locale) {
         String text = TextUtil.replace(plugin.getMsg(CommandMessage.valueOf(type.name() + "_REQUIREMENT_ADD_LORE"), locale), "{skill}", skill.getDisplayName(locale), "{level}", String.valueOf(level));
         List<String> lore;
@@ -514,12 +530,12 @@ public class SkillsItem {
         }
     }
 
-    public void removeRequirementLore(Skill skill) {
+    public void removeRequirementLore(Skill skill, Locale locale) {
         List<String> lore = meta.getLore();
         if (lore != null) {
             for (int i = 0; i < lore.size(); i++) {
                 String line = lore.get(i);
-                if (line.contains("Requires") && line.contains(TextUtil.capitalize(skill.name().toLowerCase(Locale.ROOT)))) {
+                if (line.contains("Requires") && line.contains(TextUtil.capitalize(skill.getDisplayName(locale)))) {
                     lore.remove(line);
                 }
             }

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -68,8 +68,13 @@ permissions:
     description: All permissions related to the creation of items using AuraSkills modifiers
     children:
       auraskills.command.item.modifier: true
+      auraskills.command.item.modifier.other: true
+      auraskills.command.item.trait: true
+      auraskills.command.item.trait.other: true
       auraskills.command.item.requirement: true
+      auraskills.command.item.requirement.other: true
       auraskills.command.item.multiplier: true
+      auraskills.command.item.multiplier.other: true
       auraskills.command.item.register: true
       auraskills.command.item.give: true
       auraskills.command.item.ignore: true
@@ -79,8 +84,13 @@ permissions:
     description: All permissions related to the creation of armors using AuraSkills modifiers
     children:
       auraskills.command.armor.modifier: true
+      auraskills.command.armor.modifier.other: true
+      auraskills.command.armor.trait: true
+      auraskills.command.armor.trait.other: true
       auraskills.command.armor.requirement: true
+      auraskills.command.armor.requirement.other: true
       auraskills.command.armor.multiplier: true
+      auraskills.command.armor.multiplier.other: true
     default: false
 
   auraskills.command.admin:
@@ -183,15 +193,35 @@ permissions:
     default: op
   auraskills.command.armor.modifier:
     default: op
+  auraskills.command.armor.modifier.other:
+    default: op
+  auraskills.command.armor.trait:
+    default: op
+  auraskills.command.armor.trait.other:
+    default: op
   auraskills.command.armor.requirement:
+    default: op
+  auraskills.command.armor.requirement.other:
     default: op
   auraskills.command.armor.multiplier:
     default: op
+  auraskills.command.armor.multiplier.other:
+    default: op
   auraskills.command.item.modifier:
+    default: op
+  auraskills.command.item.modifier.other:
+    default: op
+  auraskills.command.item.trait:
+    default: op
+  auraskills.command.item.trait.other:
     default: op
   auraskills.command.item.requirement:
     default: op
+  auraskills.command.item.requirement.other:
+    default: op
   auraskills.command.item.multiplier:
+    default: op
+  auraskills.command.item.multiplier.other:
     default: op
   auraskills.command.item.register:
     default: op


### PR DESCRIPTION
Rewrote the item and armor commands to allow targeting others (where applicable). Give operators and reward systems the option to use these commands.

Shared logic of the item and armor commands have been moved to a shared class. This to make maintenance on the code easier and prevent duplicate logic as much as possible.
_Example use would be an item leveling system that rewards the player stats/traits on the item._

Additionally an overwrite flag has been added to several commands that set traits/skills/modifiers.
This to allow the command to overwrite existing values (and lore if true) instead of having to remove them first.
_By default the value is false making the command function normally._

Command syntax for overwrite & (target) player:
`modifier add <stat> <value> operation] [lore] [overwrite] [player]`
`trait add <trait> <value> [operation] [lore] [overwrite] [player]`
`multiplier add <trait> <value> [operation] [lore] [overwrite] [player]`
`requirement add <skill> <level> [lore] [overwrite] [player]`

Command syntax for (target) player:
`modifier remove <stat> [lore] [player]`
`modifier list [player]`
`modifier removeall [player]`
`trait remove <stat> [lore] [player]`
`trait list [player]`
`trait removeall [player]`
`multiplier remove <stat> [lore] [player]`
`multiplier list [player]`
`multiplier removeall [player]`
`requirement remove <skill> [lore] [player]`
`requirement list [player]`
`requirement removeall [player]`

Made permissions more consistent:
`trait` commands now fall under `auraskills.command.*.trait` instead of `auraskills.command.*.modifier`