### PR TITLE
Add BlockDropItemEvent for Treecapitator & Terraform

### DIFF
--- a/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/mana/ManaAbilityBlockDropItemEvent.java
+++ b/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/mana/ManaAbilityBlockDropItemEvent.java
@@ -1,0 +1,18 @@
+package dev.aurelium.auraskills.api.event.mana;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class ManaAbilityBlockDropItemEvent extends BlockDropItemEvent {
+
+    public ManaAbilityBlockDropItemEvent(@NotNull Block theBlock, @NotNull BlockState theBlockState, @NotNull Player player, @NotNull List<Item> items) {
+        super(theBlock, theBlockState, player, items);
+    }
+
+}

--- a/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/mana/TerraformBlockDropItemEvent.java
+++ b/api-bukkit/src/main/java/dev/aurelium/auraskills/api/event/mana/TerraformBlockDropItemEvent.java
@@ -1,0 +1,17 @@
+package dev.aurelium.auraskills.api.event.mana;
+
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class TerraformBlockDropItemEvent extends ManaAbilityBlockDropItemEvent {
+
+    public TerraformBlockDropItemEvent(@NotNull Block theBlock, @NotNull BlockState theBlockState, @NotNull Player player, @NotNull List<Item> items) {
+        super(theBlock, theBlockState, player, items);
+    }
+
+}

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
@@ -126,25 +126,29 @@ public class Terraform extends ReadiedManaAbility {
         TerraformBlockBreakEvent event = new TerraformBlockBreakEvent(block, player);
         Bukkit.getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
-            List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
-            BlockState blockState = block.getState();
+            if (manaAbility.optionBoolean("call_block_drop_item_event", false)) {
+                List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
+                BlockState blockState = block.getState();
 
-            Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
-            List<Item> droppedItems = new ArrayList<>();
-            for (ItemStack drop : drops) {
-                droppedItems.add(block.getWorld().dropItem(dropLoc, drop));
-            }
-
-            TerraformBlockDropItemEvent terraformBlockDropItemEvent = new TerraformBlockDropItemEvent(block, blockState, player, droppedItems);
-            Bukkit.getPluginManager().callEvent(terraformBlockDropItemEvent);
-            if (terraformBlockDropItemEvent.isCancelled()) {
-                for (Item droppedItem : droppedItems) {
-                    droppedItem.remove();
+                Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
+                List<Item> droppedItems = new ArrayList<>();
+                for (ItemStack drop : drops) {
+                    droppedItems.add(block.getWorld().dropItem(dropLoc, drop));
                 }
-            }
 
-            block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-            block.setType(Material.AIR);
+                TerraformBlockDropItemEvent terraformBlockDropItemEvent = new TerraformBlockDropItemEvent(block, blockState, player, droppedItems);
+                Bukkit.getPluginManager().callEvent(terraformBlockDropItemEvent);
+                if (terraformBlockDropItemEvent.isCancelled()) {
+                    for (Item droppedItem : droppedItems) {
+                        droppedItem.remove();
+                    }
+                }
+
+                block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+                block.setType(Material.AIR);
+            } else {
+                block.breakNaturally(player.getInventory().getItemInMainHand());
+            }
         }
         block.removeMetadata("AureliumSkills-Terraform", plugin);
     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
@@ -130,6 +130,9 @@ public class Terraform extends ReadiedManaAbility {
                 List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
                 BlockState blockState = block.getState();
 
+                block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+                block.setType(Material.AIR);
+
                 Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
                 List<Item> droppedItems = new ArrayList<>();
                 for (ItemStack drop : drops) {
@@ -143,9 +146,6 @@ public class Terraform extends ReadiedManaAbility {
                         droppedItem.remove();
                     }
                 }
-
-                block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-                block.setType(Material.AIR);
             } else {
                 block.breakNaturally(player.getInventory().getItemInMainHand());
             }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/excavation/Terraform.java
@@ -1,6 +1,7 @@
 package dev.aurelium.auraskills.bukkit.skills.excavation;
 
 import dev.aurelium.auraskills.api.event.mana.TerraformBlockBreakEvent;
+import dev.aurelium.auraskills.api.event.mana.TerraformBlockDropItemEvent;
 import dev.aurelium.auraskills.api.mana.ManaAbilities;
 import dev.aurelium.auraskills.api.source.XpSource;
 import dev.aurelium.auraskills.api.source.type.BlockXpSource;
@@ -12,18 +13,21 @@ import dev.aurelium.auraskills.common.message.type.ManaAbilityMessage;
 import dev.aurelium.auraskills.common.source.SourceTag;
 import dev.aurelium.auraskills.common.user.User;
 import dev.aurelium.auraskills.common.util.text.TextUtil;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 public class Terraform extends ReadiedManaAbility {
 
@@ -122,7 +126,25 @@ public class Terraform extends ReadiedManaAbility {
         TerraformBlockBreakEvent event = new TerraformBlockBreakEvent(block, player);
         Bukkit.getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
-            block.breakNaturally(player.getInventory().getItemInMainHand());
+            List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
+            BlockState blockState = block.getState();
+
+            Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
+            List<Item> droppedItems = new ArrayList<>();
+            for (ItemStack drop : drops) {
+                droppedItems.add(block.getWorld().dropItem(dropLoc, drop));
+            }
+
+            TerraformBlockDropItemEvent terraformBlockDropItemEvent = new TerraformBlockDropItemEvent(block, blockState, player, droppedItems);
+            Bukkit.getPluginManager().callEvent(terraformBlockDropItemEvent);
+            if (terraformBlockDropItemEvent.isCancelled()) {
+                for (Item droppedItem : droppedItems) {
+                    droppedItem.remove();
+                }
+            }
+
+            block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+            block.setType(Material.AIR);
         }
         block.removeMetadata("AureliumSkills-Terraform", plugin);
     }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
@@ -187,6 +187,9 @@ public class Treecapitator extends ReadiedManaAbility {
                     List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
                     BlockState blockState = block.getState();
 
+                    block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+                    block.setType(Material.AIR);
+
                     Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
                     List<Item> droppedItems = new ArrayList<>();
                     for (ItemStack drop : drops) {
@@ -200,9 +203,6 @@ public class Treecapitator extends ReadiedManaAbility {
                             droppedItem.remove();
                         }
                     }
-
-                    block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-                    block.setType(Material.AIR);
                 } else {
                     block.breakNaturally(player.getInventory().getItemInMainHand());
                 }

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
@@ -3,7 +3,6 @@ package dev.aurelium.auraskills.bukkit.skills.foraging;
 import com.sk89q.worldedit.WorldEdit;
 import dev.aurelium.auraskills.api.event.mana.ManaAbilityBlockBreakEvent;
 import dev.aurelium.auraskills.api.event.mana.ManaAbilityBlockDropItemEvent;
-import dev.aurelium.auraskills.api.event.mana.TerraformBlockDropItemEvent;
 import dev.aurelium.auraskills.api.mana.ManaAbilities;
 import dev.aurelium.auraskills.api.registry.NamespacedId;
 import dev.aurelium.auraskills.api.source.XpSource;
@@ -184,25 +183,29 @@ public class Treecapitator extends ReadiedManaAbility {
             ManaAbilityBlockBreakEvent event = new ManaAbilityBlockBreakEvent(block, player);
             Bukkit.getPluginManager().callEvent(event);
             if (!event.isCancelled()) {
-                List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
-                BlockState blockState = block.getState();
+                if (manaAbility.optionBoolean("call_block_drop_item_event", false)) {
+                    List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
+                    BlockState blockState = block.getState();
 
-                Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
-                List<Item> droppedItems = new ArrayList<>();
-                for (ItemStack drop : drops) {
-                    droppedItems.add(block.getWorld().dropItem(dropLoc, drop));
-                }
-
-                ManaAbilityBlockDropItemEvent manaAbilityBlockDropItemEvent = new ManaAbilityBlockDropItemEvent(block, blockState, player, droppedItems);
-                Bukkit.getPluginManager().callEvent(manaAbilityBlockDropItemEvent);
-                if (manaAbilityBlockDropItemEvent.isCancelled()) {
-                    for (Item droppedItem : droppedItems) {
-                        droppedItem.remove();
+                    Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
+                    List<Item> droppedItems = new ArrayList<>();
+                    for (ItemStack drop : drops) {
+                        droppedItems.add(block.getWorld().dropItem(dropLoc, drop));
                     }
-                }
 
-                block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-                block.setType(Material.AIR);
+                    ManaAbilityBlockDropItemEvent manaAbilityBlockDropItemEvent = new ManaAbilityBlockDropItemEvent(block, blockState, player, droppedItems);
+                    Bukkit.getPluginManager().callEvent(manaAbilityBlockDropItemEvent);
+                    if (manaAbilityBlockDropItemEvent.isCancelled()) {
+                        for (Item droppedItem : droppedItems) {
+                            droppedItem.remove();
+                        }
+                    }
+
+                    block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+                    block.setType(Material.AIR);
+                } else {
+                    block.breakNaturally(player.getInventory().getItemInMainHand());
+                }
             }
             block.removeMetadata("AureliumSkills-Treecapitator", plugin);
         } else {

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/skills/foraging/Treecapitator.java
@@ -2,6 +2,8 @@ package dev.aurelium.auraskills.bukkit.skills.foraging;
 
 import com.sk89q.worldedit.WorldEdit;
 import dev.aurelium.auraskills.api.event.mana.ManaAbilityBlockBreakEvent;
+import dev.aurelium.auraskills.api.event.mana.ManaAbilityBlockDropItemEvent;
+import dev.aurelium.auraskills.api.event.mana.TerraformBlockDropItemEvent;
 import dev.aurelium.auraskills.api.mana.ManaAbilities;
 import dev.aurelium.auraskills.api.registry.NamespacedId;
 import dev.aurelium.auraskills.api.source.XpSource;
@@ -14,10 +16,10 @@ import dev.aurelium.auraskills.common.message.type.ManaAbilityMessage;
 import dev.aurelium.auraskills.common.source.SourceTag;
 import dev.aurelium.auraskills.common.source.type.BlockSource;
 import dev.aurelium.auraskills.common.user.User;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -27,6 +29,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -180,7 +184,25 @@ public class Treecapitator extends ReadiedManaAbility {
             ManaAbilityBlockBreakEvent event = new ManaAbilityBlockBreakEvent(block, player);
             Bukkit.getPluginManager().callEvent(event);
             if (!event.isCancelled()) {
-                block.breakNaturally(player.getInventory().getItemInMainHand());
+                List<ItemStack> drops = new ArrayList<>(block.getDrops(player.getInventory().getItemInMainHand(), player));
+                BlockState blockState = block.getState();
+
+                Location dropLoc = block.getLocation().add(0.5, 0.25, 0.5);
+                List<Item> droppedItems = new ArrayList<>();
+                for (ItemStack drop : drops) {
+                    droppedItems.add(block.getWorld().dropItem(dropLoc, drop));
+                }
+
+                ManaAbilityBlockDropItemEvent manaAbilityBlockDropItemEvent = new ManaAbilityBlockDropItemEvent(block, blockState, player, droppedItems);
+                Bukkit.getPluginManager().callEvent(manaAbilityBlockDropItemEvent);
+                if (manaAbilityBlockDropItemEvent.isCancelled()) {
+                    for (Item droppedItem : droppedItems) {
+                        droppedItem.remove();
+                    }
+                }
+
+                block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+                block.setType(Material.AIR);
             }
             block.removeMetadata("AureliumSkills-Treecapitator", plugin);
         } else {

--- a/common/src/main/resources/mana_abilities.yml
+++ b/common/src/main/resources/mana_abilities.yml
@@ -35,6 +35,7 @@ mana_abilities:
     durability_multiplier: 0
     max_limit_durability: false
     call_block_break_event: false
+    call_block_drop_item_event: false
   auraskills/speed_mine:
     enabled: true
     base_value: 10.0
@@ -81,6 +82,7 @@ mana_abilities:
     max_blocks: 61
     durability_multiplier: 0
     max_limit_durability: false
+    call_block_drop_item_event: false
   auraskills/charged_shot:
     enabled: true
     base_value: 0.5


### PR DESCRIPTION
Reworked the previous BlockDropItemEvent-related PR as simple as possible.

`Player#breakBlock` which was suggested as an existing alternative, was not adopted in this PR because it uses up the durability of the player's tools and shows a different mechanism than before.

And BlockDropItemEvent is a subordinate event to BlockBreakEvent anyway, so I just put it together as a chain event of BlockBreakEvent without any other options.