### PR TITLE
feat: delete automatic backups older than a configured number of days

### DIFF
--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
@@ -372,6 +372,9 @@ public class AuraSkills extends JavaPlugin implements AuraSkillsPlugin {
             FileUtil.saveYamlFile(metaFile, metaConfig);
 
             backupProvider.saveBackupSync(false);
+            if (configBoolean(Option.AUTOMATIC_BACKUPS_DELETE_OLD_BACKUPS)) {
+                backupProvider.deleteOldBackups();
+            }
         }
     }
 

--- a/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
+++ b/bukkit/src/main/java/dev/aurelium/auraskills/bukkit/AuraSkills.java
@@ -371,8 +371,8 @@ public class AuraSkills extends JavaPlugin implements AuraSkillsPlugin {
             metaConfig.node("last_automatic_backup").set(System.currentTimeMillis());
             FileUtil.saveYamlFile(metaFile, metaConfig);
 
-            backupProvider.saveBackupSync(false);
-            if (configBoolean(Option.AUTOMATIC_BACKUPS_DELETE_OLD_BACKUPS)) {
+            File backupFile = backupProvider.saveBackupSync(false);
+            if (backupFile != null && configBoolean(Option.AUTOMATIC_BACKUPS_DELETE_OLD_BACKUPS)) {
                 backupProvider.deleteOldBackups();
             }
         }

--- a/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/config/Option.java
@@ -174,6 +174,8 @@ public enum Option {
     AUTOMATIC_BACKUPS_ENABLED("automatic_backups.enabled", OptionType.BOOLEAN),
     AUTOMATIC_BACKUPS_MINIMUM_INTERVAL_HOURS("automatic_backups.minimum_interval_hours", OptionType.DOUBLE),
     AUTOMATIC_BACKUPS_MAX_USERS("automatic_backups.max_users", OptionType.INT),
+    AUTOMATIC_BACKUPS_DELETE_OLD_BACKUPS("automatic_backups.delete_old_backups", OptionType.BOOLEAN),
+    AUTOMATIC_BACKUPS_DELETE_OLDER_THAN_DAYS("automatic_backups.delete_older_than_days", OptionType.INT),
     SAVE_BLANK_PROFILES("save_blank_profiles", OptionType.BOOLEAN);
 
     private final String path;

--- a/common/src/main/java/dev/aurelium/auraskills/common/storage/backup/BackupProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/storage/backup/BackupProvider.java
@@ -137,8 +137,8 @@ public class BackupProvider {
             return;
         }
 
-        long deleteBefore = System.currentTimeMillis()
-                - TimeUnit.DAYS.toMillis(plugin.configInt(Option.AUTOMATIC_BACKUPS_DELETE_OLDER_THAN_DAYS));
+        int retentionDays = Math.max(1, plugin.configInt(Option.AUTOMATIC_BACKUPS_DELETE_OLDER_THAN_DAYS));
+        long deleteBefore = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
         for (File backupFile : backupFiles) {
             if (backupFile.lastModified() < deleteBefore && !backupFile.delete()) {
                 plugin.logger().warn("Failed to delete old backup " + backupFile.getName());

--- a/common/src/main/java/dev/aurelium/auraskills/common/storage/backup/BackupProvider.java
+++ b/common/src/main/java/dev/aurelium/auraskills/common/storage/backup/BackupProvider.java
@@ -28,8 +28,12 @@ import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 public class BackupProvider {
+
+    private static final Pattern BACKUP_FILE_PATTERN = Pattern.compile(
+            "backup-\\d{4}-\\d{2}-\\d{2}_\\d{1,2}-\\d{1,2}-\\d{1,2}\\.yml");
 
     public final AuraSkillsPlugin plugin;
     public final UserManager playerManager;
@@ -123,6 +127,23 @@ public class BackupProvider {
         // Save the backup file
         loader.save(config);
         return backupFile;
+    }
+
+    public void deleteOldBackups() {
+        File backupFolder = new File(plugin.getPluginFolder(), "backups");
+        File[] backupFiles = backupFolder.listFiles(file ->
+                file.isFile() && BACKUP_FILE_PATTERN.matcher(file.getName()).matches());
+        if (backupFiles == null) {
+            return;
+        }
+
+        long deleteBefore = System.currentTimeMillis()
+                - TimeUnit.DAYS.toMillis(plugin.configInt(Option.AUTOMATIC_BACKUPS_DELETE_OLDER_THAN_DAYS));
+        for (File backupFile : backupFiles) {
+            if (backupFile.lastModified() < deleteBefore && !backupFile.delete()) {
+                plugin.logger().warn("Failed to delete old backup " + backupFile.getName());
+            }
+        }
     }
 
     public void loadBackupAsync(File file, Runnable onComplete, Consumer<Throwable> onError) {

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -283,6 +283,8 @@ automatic_backups:
   enabled: true
   minimum_interval_hours: 24
   max_users: 50000
+  delete_old_backups: false
+  delete_older_than_days: 7
 save_blank_profiles: false
 experimental:
   optimize_leaderboard_updating: false


### PR DESCRIPTION
## Summary

Automatic backups can now be pruned by age on shutdown via two new config options: `automatic_backups.delete_old_backups` (boolean) and `automatic_backups.delete_older_than_days` (int). Pruning runs right after the existing automatic-backup save, determines age from the filesystem last-modified time (not the filename), and only touches files matching the plugin's `backup-<date>_<h>-<m>-<s>.yml` pattern so `meta.yml` and unrelated files are left alone.

## Why this matters

This is the maintainer-filed #417 to reduce the plugin's storage footprint. Two edge cases are handled so the cleanup never destroys data: when the server exceeds `max_users` and `saveBackupSync(false)` returns null, pruning is skipped (so a failed save cannot delete existing backups with no replacement), and `delete_older_than_days` is clamped to a positive retention so a `0` value cannot delete the backup that was just created.

## Testing

Verified the regex matches only plugin-created backups, the last-modified cutoff prunes older files while keeping recent ones, and the no-new-backup and zero-retention paths are both no-ops.

Fixes #417
